### PR TITLE
update: README.mdをZig移行プロジェクト向けに更新

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,3 @@ make madbd34:default:flash
 - [QMK Firmware](https://github.com/qmk/qmk_firmware)
 - [QMK ドキュメント](https://docs.qmk.fm)
 
-## ライセンス
-
-[GPL-2.0-or-later](LICENSE)


### PR DESCRIPTION
## Description

upstreamのQMK紹介文から、C→Zig移行プロジェクトとしての内容に書き換え。

- プロジェクト概要・目的
- 対象キーボード（madbd34）
- 移行方針
- フェーズごとの進捗状況テーブル
- 既存C版のビルド手順
- upstream リンク

## Types of Changes

- [x] Documentation

## Issues Fixed or Closed by This PR

* なし

## Checklist

- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).