### PR TITLE
chore: Cユニットテスト CI ワークフローの修正

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: C Unit Tests
 
 permissions:
   contents: read
@@ -7,7 +7,6 @@ on:
   push:
     branches:
     - master
-    - develop
   pull_request:
     paths:
     - 'builddefs/**'
@@ -15,6 +14,7 @@ on:
     - 'platforms/**'
     - 'tmk_core/**'
     - 'tests/**'
+    - 'lib/googletest/**'
     - '*.mk'
     - 'Makefile'
     - '.github/workflows/unit_test.yml'
@@ -26,12 +26,15 @@ jobs:
     container: ghcr.io/qmk/qmk_cli
 
     steps:
-    - uses: actions/checkout@v6
+    - name: Disable safe.directory check
+      run: git config --global --add safe.directory '*'
+
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Install dependencies
       run: pip3 install -r requirements-dev.txt
 
-    - name: Run tests
-      run: qmk test-c
+    - name: Run C unit tests
+      run: make test:all


### PR DESCRIPTION
## Description

Cユニットテスト（googletest）の CI ワークフロー（`.github/workflows/unit_test.yml`）を修正し、正しく動作するようにした。

Zig移行後もC版テストを回帰テストとして使い、互換性を検証するための環境整備。

### 変更内容

- `actions/checkout@v6` を `@v4` に修正（v6は存在しないバージョン）
- コンテナ環境で必要な `git config --global --add safe.directory '*'` を追加
- 存在しない `develop` ブランチのトリガーを削除
- `lib/googletest/**` をパスフィルタに追加（googletestの変更でもCIを実行）
- `qmk test-c` を `make test:all` に変更（直接的なテスト実行）
- ワークフロー名を「C Unit Tests」に変更して目的を明確化

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Cユニットテストの CI が正しく動作するようになる

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the PR Checklist document and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).