### PR TITLE
chore: lint/format ワークフローの actions/checkout バージョン修正

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Disable safe.directory check
       run : git config --global --add safe.directory '*'
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Disable safe.directory check
       run : git config --global --add safe.directory '*'
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
## Description

lint.yml と format.yml の `actions/checkout@v6` を `@v4` に修正する。

`actions/checkout@v6` は存在しないバージョンであり、ワークフローが実行時にエラーになる。
PR #36 で unit_test.yml は修正済みのため、残りの2ファイルを修正する。

### 変更内容

- `.github/workflows/lint.yml`: `actions/checkout@v6` → `@v4`
- `.github/workflows/format.yml`: `actions/checkout@v6` → `@v4`

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* lint/format CI ワークフローが正しく動作するようになる

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the PR Checklist document and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).