### PR TITLE
update: ドキュメントをmasterの最新実装状況に整合

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ src/
 │   ├── action_tapping.zig         # タップ/ホールド判定ステートマシン
 │   ├── action_tapping_test.zig    # タッピングのユニットテスト
 │   ├── host.zig                   # HostDriver インターフェース、レポート状態管理
+│   ├── bootmagic.zig              # Bootmagic Lite（起動時キー検出→BOOTSEL）
 │   ├── test_driver.zig            # モック HID ドライバ（テスト用）
 │   └── test_fixture.zig           # キーボードシミュレーション環境（テスト用）
 ├── hal/                           # ハードウェア抽象化層（RP2040）
@@ -96,7 +97,8 @@ src/
 │   ├── bootloader.zig             # BOOTSEL モードジャンプ（Watchdog リセット）
 │   └── vector_table.zig           # ARM Cortex-M0+ 割り込みベクタテーブル
 ├── drivers/                       # ドライバ（未実装）
-└── keyboards/                     # キーボード定義（未実装）
+└── keyboards/                     # キーボード定義
+    └── madbd34.zig                # madbd34 キーボード定義（ピン配置、LAYOUT、キーマップ）
 ```
 
 設計方針:

--- a/readme.md
+++ b/readme.md
@@ -28,8 +28,8 @@
 | Foundation | ビルドシステム、コアデータ型、テストインフラ | 完了 |
 | HAL | GPIO, Timer, EEPROM, Boot2, クロック初期化, USB HID | 完了 |
 | Core | マトリックススキャン, デバウンス, キーマップ, レイヤー管理, アクション処理 | 完了 |
-| Feature | Bootmagic, Mousekey, Extrakey | 進行中 |
-| Keyboard | madbd34 キーボード定義、統合テスト | 未着手 |
+| Feature | Bootmagic, Mousekey, Extrakey | 進行中（Extrakey 未実装） |
+| Keyboard | madbd34 キーボード定義、統合テスト | 進行中（統合テスト未実装） |
 
 ### 実装済みモジュール
 
@@ -48,6 +48,7 @@
 | アクション処理 | `action.zig` | アクション解決・実行の中核 |
 | タッピング | `action_tapping.zig` | タップ/ホールド判定ステートマシン |
 | ホストドライバ | `host.zig` | HID レポート送信インターフェース |
+| Bootmagic | `bootmagic.zig` | Bootmagic Lite（起動時キー検出） |
 | テストドライバ | `test_driver.zig` | モック HID ドライバ（テスト用） |
 | テストフィクスチャ | `test_fixture.zig` | キーボードシミュレーション環境（テスト用） |
 
@@ -64,6 +65,12 @@
 | クロック | `clock.zig` | RP2040 クロックツリー初期化（XOSC, PLL, clk_sys） |
 | ブートローダー | `bootloader.zig` | BOOTSEL モードへのジャンプ |
 | ベクタテーブル | `vector_table.zig` | ARM Cortex-M0+ 割り込みベクタテーブル |
+
+**Keyboards** (`src/keyboards/`)
+
+| モジュール | ファイル | 説明 |
+|-----------|---------|------|
+| madbd34 | `madbd34.zig` | madbd34 キーボード定義（ピン配置、LAYOUT、キーマップ） |
 
 ## ビルド
 


### PR DESCRIPTION
## Description

PR #41 マージ後にmasterに追加された実装（Bootmagic, Mousekey, madbd34キーボード定義等）を反映してドキュメントを修正。

### 変更内容

**README.md:**
- `bootmagic.zig` を Core モジュール一覧に復帰（PR #38 でマージ済み）
- Feature フェーズの状態を更新（Bootmagic/Mousekey 完了、Extrakey のみ未実装）
- Keyboard フェーズを「進行中」に更新（madbd34.zig 実装済み、統合テスト未実装）
- Keyboards モジュール一覧テーブルを追加（madbd34.zig）

**CLAUDE.md:**
- `bootmagic.zig` をファイルツリーに復帰
- `keyboards/madbd34.zig` をファイルツリーに追加

### 確認事項
- `zig build test` 通過確認済み
- `src/core/`、`src/hal/`、`src/keyboards/` の実ファイルとドキュメント記載が完全一致

## Types of Changes

- [x] Documentation

## Issues Fixed or Closed by This PR

* PR #41 レビュー指摘の最終対応

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).