### PR TITLE
feat: zig build flash ステップの追加（RP2040 BOOTSELフラッシュ）

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -42,8 +42,8 @@ pub fn build(b: *std.Build) void {
 
     // Flash step: build UF2 and copy to RP2040 BOOTSEL drive
     const flash_step = b.step("flash", "Flash firmware to RP2040 via BOOTSEL mode");
-    const flash_install = addFlashStep(b, uf2_install, native_target, keyboard, keymap);
-    flash_step.dependOn(&flash_install.step);
+    const flash_run = addFlashStep(b, uf2_install, native_target, keyboard, keymap);
+    flash_step.dependOn(&flash_run.step);
 
     // Test target (native host)
     const test_step = b.step("test", "Run unit tests");

--- a/tools/flash.zig
+++ b/tools/flash.zig
@@ -146,6 +146,7 @@ fn detectBootselWindows(allocator: std.mem.Allocator) ![]const u8 {
     const drive_letters = "DEFGHIJKLMNOPQRSTUVWXYZ";
     for (drive_letters) |letter| {
         const drive_path = try std.fmt.allocPrint(allocator, "{c}:\\", .{letter});
+        errdefer allocator.free(drive_path);
 
         // Check if the drive exists and is accessible
         if (isDirectory(drive_path)) {
@@ -164,8 +165,8 @@ fn detectBootselWindows(allocator: std.mem.Allocator) ![]const u8 {
 }
 
 fn isDirectory(path: []const u8) bool {
-    const dir = std.fs.cwd().openDir(path, .{}) catch return false;
-    @constCast(&dir).close();
+    var dir = std.fs.cwd().openDir(path, .{}) catch return false;
+    dir.close();
     return true;
 }
 


### PR DESCRIPTION
## Description

`build.zig` に `zig build flash` ステップを追加し、UF2ビルドからRP2040 BOOTSELドライブへのフラッシュ書き込みまでを一括実行できるようにした。

PR #35 で削除された `Makefile.zig` のflash機能を `build.zig` ネイティブに再実装。

### 変更内容

- **`tools/flash.zig`**: BOOTSELドライブ検出・UF2コピーツール（新規）
  - macOS: `/Volumes/RPI-RP2`
  - Linux: `/media/$USER/RPI-RP2`, `/run/media/$USER/RPI-RP2`, `/mnt/RPI-RP2`
  - Windows: `D:`〜`Z:` ドライブレター走査（`INFO_UF2.TXT` の存在で判定）
  - ドライブ未検出時の日本語エラーメッセージ表示
- **`build.zig`**: `flash` ステップ追加
  - 既存の `uf2` ステップに依存し、UF2生成後に自動でフラッシュ実行
  - `addFlashStep` 関数で `tools/flash.zig` をネイティブツールとしてビルド・実行

### 使い方

```bash
# UF2ビルド＋フラッシュ（BOOTSELモードで接続済みの場合）
zig build flash

# boot2付きでフラッシュ
zig build flash -Dboot2=path/to/boot2.bin
```

BOOTSELドライブが見つからない場合、接続手順のガイダンスが表示される。

## Types of Changes

- [x] New feature

## Issues Fixed or Closed by This PR

* Closes #37

## Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).