### PR TITLE
nit: CIステップ名「Build (native check)」を実態に合わせて修正

### DIFF
--- a/.github/workflows/zig_test.yml
+++ b/.github/workflows/zig_test.yml
@@ -36,5 +36,5 @@ jobs:
     - name: Run tests
       run: zig build test
 
-    - name: Build (native check)
+    - name: Build firmware (RP2040 cross-compile)
       run: zig build


### PR DESCRIPTION
## Description

CI ワークフロー `.github/workflows/zig_test.yml` のステップ名「Build (native check)」を修正。

`zig build` は RP2040 (ARM Cortex-M0+) 向けのクロスコンパイルを実行するため、ネイティブビルドではない。
ステップ名を「Build firmware (RP2040 cross-compile)」に変更し、実態と一致させる。

## Types of Changes

- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #57

## Checklist

- [x] My code follows the code style of this project
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).