### PR TITLE
fix: Claude Code GitHub Actions のパーミッションを write に修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## 概要

Claude Code GitHub Actions (`claude-code-action@v1`) がPR/Issueにレビューコメントを投稿できない問題を修正。

## 原因

`pull-requests` と `issues` のパーミッションが `read` に設定されていたため、Claude Code Action がコメントを書き込めなかった。

## 変更内容

- `pull-requests: read` → `pull-requests: write`
- `issues: read` → `issues: write`

## テスト計画

- [ ] この PR がマージされた後、他の PR に `@claude` コメントしてレビューが投稿されることを確認