### PR TITLE
fix: claude.yml の permissions を read に戻す

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary

- `pull-requests: write` → `read` に戻す
- `issues: write` → `read` に戻す

## 変更理由

PR #66 でコメント投稿のために `write` が必要と判断して変更したが、Claude Code Action のコメント投稿は `claude_code_oauth_token`（Claude bot の OAuth トークン）が担うため、ワークフローの `GITHUB_TOKEN` は `read` で十分。

`write` に変えたことで Action がコメント投稿に使うトークンの選択に影響が出た可能性があるため、動作実績のある他リポジトリの設定（`read`）に戻す。

## 関連

- Reverts part of #66