### PR TITLE
feat: KeymapConfig の EEPROM 永続化（eeconfig 連携）

### DIFF
--- a/src/core/eeconfig.zig
+++ b/src/core/eeconfig.zig
@@ -6,7 +6,6 @@
 
 const std = @import("std");
 const eeprom = @import("../hal/eeprom.zig");
-const keymap_mod = @import("keymap.zig");
 
 /// C版 eeprom_core_t 互換のEEPROMアドレスレイアウト（quantum/nvm/eeprom/nvm_eeprom_eeconfig_internal.h 参照）
 /// struct PACKED {
@@ -27,7 +26,7 @@ const EECONFIG_DEBUG_ADDR: u16 = 2;
 const EECONFIG_DEFAULT_LAYER_ADDR: u16 = 3;
 
 /// EEPROM keymap_config のアドレス（C版 EECONFIG_KEYMAP に相当）
-const EECONFIG_KEYMAP_ADDR: u16 = 4;
+pub const EECONFIG_KEYMAP_ADDR: u16 = 4;
 
 /// EEPROM magic number（有効な設定が書き込まれていることを示す）
 const EECONFIG_MAGIC_NUMBER: u16 = 0xFEED;
@@ -58,21 +57,20 @@ pub fn enable() void {
 // upstream の eeconfig_read_keymap() / eeconfig_update_keymap() に相当
 // ============================================================
 
-/// EEPROMから KeymapConfig を読み出す
+/// EEPROMから keymap 設定を読み出す（raw u16）
 /// upstream の eeconfig_read_keymap() に相当。
-/// EEPROMが無効な場合はデフォルト値（全フラグ OFF）を返す。
-pub fn readKeymapConfig() keymap_mod.KeymapConfig {
+/// EEPROMが無効な場合は 0 を返す。
+/// 呼び出し側で @bitCast(KeymapConfig) に変換して使用する。
+pub fn readKeymap() u16 {
     if (!isEnabled()) {
-        return .{};
+        return 0;
     }
-    const raw = eeprom.readWord(EECONFIG_KEYMAP_ADDR);
-    return @bitCast(raw);
+    return eeprom.readWord(EECONFIG_KEYMAP_ADDR);
 }
 
-/// KeymapConfig を EEPROM に書き込む
+/// keymap 設定を EEPROM に書き込む（raw u16）
 /// upstream の eeconfig_update_keymap() に相当。
-pub fn updateKeymapConfig(config: keymap_mod.KeymapConfig) void {
-    const raw: u16 = @bitCast(config);
+pub fn updateKeymap(raw: u16) void {
     eeprom.writeWord(EECONFIG_KEYMAP_ADDR, raw);
 }
 
@@ -93,4 +91,27 @@ test "eeconfig: 有効化/無効化" {
     // 無効化
     disable();
     try std.testing.expect(!isEnabled());
+}
+
+test "eeconfig: readKeymap/updateKeymap ラウンドトリップ" {
+    eeprom.mockReset();
+    enable();
+
+    // 書き込み → 読み出しで一致する
+    const test_value: u16 = 0x1234;
+    updateKeymap(test_value);
+    try std.testing.expectEqual(test_value, readKeymap());
+
+    // 別の値で上書き
+    const test_value2: u16 = 0xABCD;
+    updateKeymap(test_value2);
+    try std.testing.expectEqual(test_value2, readKeymap());
+}
+
+test "eeconfig: readKeymap は未有効時にデフォルト値を返す" {
+    eeprom.mockReset();
+
+    // EEPROM が無効なので 0 が返る
+    try std.testing.expect(!isEnabled());
+    try std.testing.expectEqual(@as(u16, 0), readKeymap());
 }

--- a/src/core/keymap.zig
+++ b/src/core/keymap.zig
@@ -118,14 +118,15 @@ pub fn modConfig(mod: u8) u8 {
 /// C版 quantum/keymap.c の eeconfig_read_keymap() 呼び出し相当。
 /// EEPROMが未初期化の場合はデフォルト値のまま（全フラグ OFF）。
 pub fn keymapInit() void {
-    keymap_config = eeconfig.readKeymapConfig();
+    const raw = eeconfig.readKeymap();
+    keymap_config = @bitCast(raw);
 }
 
 /// KeymapConfig を更新し、EEPROM に永続化する
 /// C版 eeconfig_update_keymap() 呼び出しを行う箇所に相当。
 pub fn updateKeymapConfig(config: KeymapConfig) void {
     keymap_config = config;
-    eeconfig.updateKeymapConfig(config);
+    eeconfig.updateKeymap(@bitCast(config));
 }
 
 /// Keymap type: [layer][row][col] = Keycode


### PR DESCRIPTION
## 概要

KeymapConfig の EEPROM 永続化機能を実装。C版 `quantum/eeconfig.c` の移植。

## 変更内容

- eeconfig モジュールの実装（EEPROM 読み書き）
- KeymapConfig の保存・読み込み
- ユニットテスト

## テスト

- `zig build test` 通過確認済み

closes #128