### PR TITLE
chore: Markdownファイルのインデントサイズを .editorconfig に追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,7 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+indent_size = 2
 
 [{Makefile,*.mk}]
 indent_style = tab


### PR DESCRIPTION
## 概要

- `.editorconfig` の `[*.md]` セクションに `indent_size = 2` を追加

## 変更内容

Markdownファイルに対するインデントサイズの設定が未定義だったため、明示的に `indent_size = 2` を指定した。

## テスト

設定ファイルの変更のみのため、機能テストは不要。