### PR TITLE
fix: Key Override の再レビュー suggestion 対応

### DIFF
--- a/src/core/action.zig
+++ b/src/core/action.zig
@@ -23,7 +23,6 @@ const caps_word = @import("caps_word.zig");
 const repeat_key = @import("repeat_key.zig");
 const layer_lock = @import("layer_lock.zig");
 const key_lock = @import("key_lock.zig");
-const key_override = @import("key_override.zig");
 const grave_esc = @import("grave_esc.zig");
 
 const Action = action_code.Action;
@@ -260,18 +259,6 @@ fn processSpecialAction(ev: KeyEvent, act: Action) bool {
         },
         action_code.ACTION_GRAVE_ESCAPE => {
             grave_esc.processGraveEsc(ev.pressed);
-            return true;
-        },
-        action_code.ACTION_KEY_OVERRIDE_TOGGLE => {
-            if (ev.pressed) key_override.toggle();
-            return true;
-        },
-        action_code.ACTION_KEY_OVERRIDE_ON => {
-            if (ev.pressed) key_override.on();
-            return true;
-        },
-        action_code.ACTION_KEY_OVERRIDE_OFF => {
-            if (ev.pressed) key_override.off();
             return true;
         },
         else => return false,

--- a/src/core/action_code.zig
+++ b/src/core/action_code.zig
@@ -129,9 +129,6 @@ pub const ACTION_REPEAT_KEY: u16 = 0xF002;
 pub const ACTION_ALT_REPEAT_KEY: u16 = 0xF003;
 pub const ACTION_LAYER_LOCK: u16 = 0xF004;
 pub const ACTION_GRAVE_ESCAPE: u16 = 0xF005;
-pub const ACTION_KEY_OVERRIDE_TOGGLE: u16 = 0xF006;
-pub const ACTION_KEY_OVERRIDE_ON: u16 = 0xF007;
-pub const ACTION_KEY_OVERRIDE_OFF: u16 = 0xF008;
 
 // ============================================================
 // Action constructor functions (comptime equivalents of C macros)
@@ -425,16 +422,8 @@ pub fn keycodeToAction(kc: Keycode) Action {
         return .{ .code = ACTION_GRAVE_ESCAPE };
     }
 
-    // Key Override
-    if (kc == keycode.QK_KEY_OVERRIDE_TOGGLE) {
-        return .{ .code = ACTION_KEY_OVERRIDE_TOGGLE };
-    }
-    if (kc == keycode.QK_KEY_OVERRIDE_ON) {
-        return .{ .code = ACTION_KEY_OVERRIDE_ON };
-    }
-    if (kc == keycode.QK_KEY_OVERRIDE_OFF) {
-        return .{ .code = ACTION_KEY_OVERRIDE_OFF };
-    }
+    // Key Override (KO_TOGG/KO_ON/KO_OFF) はアクションコード不要。
+    // keyboard.zig のプリプロセスで processKeyOverride() が直接消費する。
 
     // Swap Hands (0x5600-0x56FF)
     if (kc >= keycode.QK_SWAP_HANDS and kc <= keycode.QK_SWAP_HANDS_MAX) {

--- a/src/core/key_override.zig
+++ b/src/core/key_override.zig
@@ -383,7 +383,8 @@ fn clearActiveOverride(allow_reregister: bool) ?usize {
             // C版同様: 修飾キー replacement は先にレポートを送信してから unregister する
             host.sendKeyboardReport();
             host.unregisterCode(@truncate(mod_free_replacement));
-        } else if (mod_free_replacement <= 0x00FF) {
+        } else {
+            // unregister_replacement が true の時点で mod_free_replacement <= 0x00FF は保証済み
             host.getReport().removeKey(@truncate(mod_free_replacement));
         }
     }


### PR DESCRIPTION
## Description

PR #165 (feat: Key Override 機能を実装) の再レビューで指摘された suggestion 2件に対応する。

### 変更内容

1. **clearActiveOverride 内の冗長な条件チェック除去** (`key_override.zig`)
   - `else if (mod_free_replacement <= 0x00FF)` → `else` に簡略化
   - 外側の `unregister_replacement` チェックで既に `<= 0x00FF` は保証済み

2. **デッドコードの削除** (`action_code.zig`, `action.zig`)
   - `ACTION_KEY_OVERRIDE_TOGGLE/ON/OFF` アクションコード定数を削除
   - `processSpecialAction` 内の対応する switch ケースを削除
   - `action.zig` からの `key_override` import を削除
   - KO_TOGG/KO_ON/KO_OFF は `keyboard.zig` のプリプロセスで `processKeyOverride()` が直接消費するため、アクションパイプラインには到達しない

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* なし（PR #165 のフォローアップ）

## Checklist

- [x] My code follows the code style of this project
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).