### PR TITLE
fix: Magic Keycodes レビュー対応

### DIFF
--- a/src/core/keycode.zig
+++ b/src/core/keycode.zig
@@ -409,8 +409,6 @@ pub const KO_ON: Keycode = QK_KEY_OVERRIDE_ON;
 pub const KO_OFF: Keycode = QK_KEY_OVERRIDE_OFF;
 
 // Magic Keycodes (0x7000-0x7022)
-pub const QK_MAGIC: Keycode = 0x7000;
-pub const QK_MAGIC_MAX: Keycode = 0x70FF;
 pub const QK_MAGIC_SWAP_CONTROL_CAPS_LOCK: Keycode = 0x7000;
 pub const QK_MAGIC_UNSWAP_CONTROL_CAPS_LOCK: Keycode = 0x7001;
 pub const QK_MAGIC_TOGGLE_CONTROL_CAPS_LOCK: Keycode = 0x7002;

--- a/src/core/magic.zig
+++ b/src/core/magic.zig
@@ -121,7 +121,11 @@ pub fn process(kc: Keycode, pressed: bool) bool {
 
         // EE_HANDS_LEFT/RIGHT は省略（スプリット判定のハンドシェイク未実装）
         // 通常アクションパイプラインに流さず、ここで消費する
-        keycode_mod.EH_LEFT, keycode_mod.EH_RGHT => return false,
+        // C版同様に clearKeyboard() でスタック防止
+        keycode_mod.EH_LEFT, keycode_mod.EH_RGHT => {
+            host.clearKeyboard();
+            return false;
+        },
 
         else => return true,
     }


### PR DESCRIPTION
## 概要

PR #170 の @claude レビュー suggestion 2件への対応。マージ後に修正コミットが反映されていなかったため、別PRで対応。

## 変更内容

- `src/core/keycode.zig`: 未使用の `QK_MAGIC` / `QK_MAGIC_MAX` 定数を削除
- `src/core/magic.zig`: `EH_LEFT`/`EH_RGHT` 処理で `host.clearKeyboard()` を呼ぶように修正（C版同様のスタック防止）

## テスト

- `zig build test` 全テスト通過