### PR TITLE
test: Layer Lock テストの C版移植

### DIFF
--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -212,6 +212,10 @@ pub fn task() void {
     // Secure タイムアウト処理
     secure.task();
 
+    // Layer Lock タイムアウト・レイヤー状態同期処理
+    layer_lock.task();
+    layer_lock.syncWithLayerState();
+
     // 現在の状態を保存
     matrix_prev = matrix_state;
 }

--- a/src/core/layer_lock.zig
+++ b/src/core/layer_lock.zig
@@ -6,9 +6,17 @@
 //! Layer Lock キーを再度押すとロック解除される。
 
 const layer = @import("layer.zig");
+const host = @import("host.zig");
+const timer = @import("../hal/timer.zig");
 
 /// ロック中のレイヤーをビットマスクで管理
 var locked_layers: layer.LayerState = 0;
+
+/// アイドルタイムアウト（ミリ秒、0 = 無効）
+pub var idle_timeout: u32 = 0;
+
+/// タイムアウト計測用タイマー
+var lock_timer: u32 = 0;
 
 /// 指定レイヤーがロックされているか確認
 pub fn isLayerLocked(l: u5) bool {
@@ -32,15 +40,79 @@ pub fn processLayerLock(pressed: bool) void {
         locked_layers &= ~(@as(layer.LayerState, 1) << top_layer);
         layer.layerOff(top_layer);
     } else {
-        // ロック: レイヤーをオンにして記録
+        // ロック: OSL で有効化されていた場合、oneshot を解除して
+        // レイヤーが自動解除されないようにする
+        if (top_layer == host.getOneshotLayer()) {
+            host.resetOneshotLayer();
+        }
         locked_layers |= @as(layer.LayerState, 1) << top_layer;
         layer.layerOn(top_layer);
+        activityTrigger();
     }
+}
+
+/// 指定レイヤーのロック状態をトグルする
+/// C版 layer_lock_invert() に相当
+pub fn layerLockInvert(l: u5) void {
+    const mask = @as(layer.LayerState, 1) << l;
+    if ((locked_layers & mask) == 0) {
+        if (l == host.getOneshotLayer()) {
+            host.resetOneshotLayer();
+        }
+        layer.layerOn(l);
+        activityTrigger();
+    } else {
+        layer.layerOff(l);
+    }
+    locked_layers ^= mask;
+}
+
+/// 指定レイヤーをロックする（既にロック済みなら何もしない）
+pub fn layerLockOn(l: u5) void {
+    if (!isLayerLocked(l)) {
+        layerLockInvert(l);
+    }
+}
+
+/// 指定レイヤーのロックを解除する（ロックされていなければ何もしない）
+pub fn layerLockOff(l: u5) void {
+    if (isLayerLocked(l)) {
+        layerLockInvert(l);
+    }
+}
+
+/// 全レイヤーのロックを解除する
+pub fn layerLockAllOff() void {
+    layer.layerAnd(~locked_layers);
+    locked_layers = 0;
+}
+
+/// アイドルタイムアウト処理（keyboard.task() から呼ばれる）
+pub fn task() void {
+    if (idle_timeout > 0 and locked_layers != 0) {
+        if (timer.elapsed32(lock_timer) > idle_timeout) {
+            layerLockAllOff();
+            lock_timer = timer.read32();
+        }
+    }
+}
+
+/// アクティビティトリガー（ロック操作時にタイマーリセット）
+pub fn activityTrigger() void {
+    lock_timer = timer.read32();
+}
+
+/// レイヤー状態との同期
+pub fn syncWithLayerState() void {
+    const current = layer.getLayerState();
+    locked_layers &= current;
 }
 
 /// Layer Lock 状態のリセット
 pub fn reset() void {
     locked_layers = 0;
+    idle_timeout = 0;
+    lock_timer = 0;
 }
 
 /// ロック中のレイヤー状態を取得（テスト用）
@@ -64,20 +136,11 @@ test "layer lock: initial state has no locked layers" {
 test "layer lock: lock and unlock a layer" {
     reset();
     layer.resetState();
-
-    // レイヤー1をアクティブにする
     layer.layerOn(1);
     try testing.expect(layer.layerStateIs(1));
-
-    // Layer Lock を押す -> レイヤー1がロックされる
     processLayerLock(true);
     try testing.expect(isLayerLocked(1));
     try testing.expect(layer.layerStateIs(1));
-
-    // MO(1) を離してもロックされているのでレイヤーは維持される（外部でlayerOffは呼ばれない想定）
-    // ここではロック状態の確認のみ
-
-    // 再度 Layer Lock を押す -> レイヤー1がアンロックされる
     processLayerLock(true);
     try testing.expect(!isLayerLocked(1));
     try testing.expect(!layer.layerStateIs(1));
@@ -86,17 +149,14 @@ test "layer lock: lock and unlock a layer" {
 test "layer lock: release does nothing" {
     reset();
     layer.resetState();
-
     layer.layerOn(1);
-    processLayerLock(false); // リリースは無視
+    processLayerLock(false);
     try testing.expect(!isLayerLocked(1));
 }
 
 test "layer lock: layer 0 is not lockable" {
     reset();
     layer.resetState();
-
-    // layer_state=0 のとき最上位レイヤーは0
     processLayerLock(true);
     try testing.expect(!isLayerLocked(0));
 }
@@ -104,11 +164,8 @@ test "layer lock: layer 0 is not lockable" {
 test "layer lock: locks highest active layer" {
     reset();
     layer.resetState();
-
     layer.layerOn(1);
     layer.layerOn(3);
-
-    // 最上位のレイヤー3がロックされる
     processLayerLock(true);
     try testing.expect(isLayerLocked(3));
     try testing.expect(!isLayerLocked(1));
@@ -117,12 +174,58 @@ test "layer lock: locks highest active layer" {
 test "layer lock: reset clears all locks" {
     reset();
     layer.resetState();
-
     layer.layerOn(1);
     processLayerLock(true);
     try testing.expect(isLayerLocked(1));
-
     reset();
     try testing.expect(!isLayerLocked(1));
     try testing.expectEqual(@as(layer.LayerState, 0), locked_layers);
+}
+
+test "layer lock: layerLockInvert toggles lock state" {
+    reset();
+    layer.resetState();
+    layerLockInvert(2);
+    try testing.expect(isLayerLocked(2));
+    try testing.expect(layer.layerStateIs(2));
+    layerLockInvert(2);
+    try testing.expect(!isLayerLocked(2));
+    try testing.expect(!layer.layerStateIs(2));
+}
+
+test "layer lock: layerLockOn and layerLockOff" {
+    reset();
+    layer.resetState();
+    layerLockOn(3);
+    try testing.expect(isLayerLocked(3));
+    layerLockOn(3);
+    try testing.expect(isLayerLocked(3));
+    layerLockOff(3);
+    try testing.expect(!isLayerLocked(3));
+    layerLockOff(3);
+    try testing.expect(!isLayerLocked(3));
+}
+
+test "layer lock: layerLockAllOff clears all locks" {
+    reset();
+    layer.resetState();
+    layerLockOn(1);
+    layerLockOn(3);
+    try testing.expect(isLayerLocked(1));
+    try testing.expect(isLayerLocked(3));
+    layerLockAllOff();
+    try testing.expect(!isLayerLocked(1));
+    try testing.expect(!isLayerLocked(3));
+    try testing.expect(!layer.layerStateIs(1));
+    try testing.expect(!layer.layerStateIs(3));
+}
+
+test "layer lock: syncWithLayerState removes stale locks" {
+    reset();
+    layer.resetState();
+    layerLockOn(1);
+    try testing.expect(isLayerLocked(1));
+    layer.layerOff(1);
+    syncWithLayerState();
+    try testing.expect(!isLayerLocked(1));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -159,6 +159,7 @@ test {
     _ = @import("tests/test_secure.zig");
     _ = @import("tests/test_tri_layer.zig");
     _ = @import("tests/test_auto_shift.zig");
+    _ = @import("tests/test_layer_lock.zig");
     // C ABI互換性テストを実行
     _ = @import("compat/abi_test.zig");
     _ = @import("compat/qmk_abi.zig");

--- a/src/tests/test_layer_lock.zig
+++ b/src/tests/test_layer_lock.zig
@@ -1,0 +1,247 @@
+//! Layer Lock テスト - C版 tests/layer_lock/test_layer_lock.cpp の Zig 移植
+//!
+//! upstream参照: tests/layer_lock/test_layer_lock.cpp (284行)
+//!
+//! C版テスト対応:
+//! 1. LayerLockState            — layer_lock_invert/on/off/all_off の API テスト
+//! 2. LayerLockMomentaryTest    — MO(1) + QK_LAYER_LOCK の統合テスト
+//! 3. LayerLockLayerTapTest     — LT(1, KC_B) + QK_LAYER_LOCK の統合テスト
+//! 4-5. OSL テスト              — OSL + Layer Lock のタッピングパイプライン相互作用は要追加調査
+//! 6. LayerLockTimeoutTest      — アイドルタイムアウトで自動アンロック
+//! 7. ToKeyOverridesLayerLock   — TO(0) で Layer Lock が上書きされる
+//! 8. LayerClearOverridesLayerLock — layer_clear() で Layer Lock が上書きされる
+
+const std = @import("std");
+const testing = std.testing;
+
+const keycode = @import("../core/keycode.zig");
+const layer_mod = @import("../core/layer.zig");
+const layer_lock = @import("../core/layer_lock.zig");
+const test_fixture = @import("../core/test_fixture.zig");
+
+const KC = keycode.KC;
+const TestFixture = test_fixture.TestFixture;
+const KeymapKey = test_fixture.KeymapKey;
+const TAPPING_TERM = test_fixture.TAPPING_TERM;
+
+const LAYER_LOCK_IDLE_TIMEOUT: u32 = 1000;
+
+// ============================================================
+// 1. LayerLockState
+// ============================================================
+
+test "LayerLockState" {
+    layer_lock.reset();
+    layer_mod.resetState();
+
+    try testing.expect(!layer_lock.isLayerLocked(1));
+    try testing.expect(!layer_lock.isLayerLocked(2));
+    try testing.expect(!layer_lock.isLayerLocked(3));
+
+    layer_lock.layerLockInvert(1);
+    layer_lock.layerLockOn(2);
+    layer_lock.layerLockOff(3);
+
+    try testing.expect(layer_mod.layerStateIs(1));
+    try testing.expect(layer_mod.layerStateIs(2));
+    try testing.expect(layer_lock.isLayerLocked(1));
+    try testing.expect(layer_lock.isLayerLocked(2));
+    try testing.expect(!layer_lock.isLayerLocked(3));
+
+    layer_lock.layerLockInvert(1);
+    layer_lock.layerLockOn(2);
+    layer_lock.layerLockOn(3);
+
+    try testing.expect(!layer_mod.layerStateIs(1));
+    try testing.expect(layer_mod.layerStateIs(2));
+    try testing.expect(layer_mod.layerStateIs(3));
+    try testing.expect(!layer_lock.isLayerLocked(1));
+    try testing.expect(layer_lock.isLayerLocked(2));
+    try testing.expect(layer_lock.isLayerLocked(3));
+
+    layer_lock.layerLockInvert(1);
+    layer_lock.layerLockOff(2);
+
+    try testing.expect(layer_mod.layerStateIs(1));
+    try testing.expect(!layer_mod.layerStateIs(2));
+    try testing.expect(layer_mod.layerStateIs(3));
+    try testing.expect(layer_lock.isLayerLocked(1));
+    try testing.expect(!layer_lock.isLayerLocked(2));
+    try testing.expect(layer_lock.isLayerLocked(3));
+
+    layer_lock.layerLockAllOff();
+
+    try testing.expect(!layer_mod.layerStateIs(1));
+    try testing.expect(!layer_mod.layerStateIs(2));
+    try testing.expect(!layer_mod.layerStateIs(3));
+    try testing.expect(!layer_lock.isLayerLocked(1));
+    try testing.expect(!layer_lock.isLayerLocked(2));
+    try testing.expect(!layer_lock.isLayerLocked(3));
+}
+
+// ============================================================
+// 2. LayerLockMomentaryTest
+// ============================================================
+
+test "LayerLockMomentaryTest" {
+    var fixture = TestFixture.init();
+    fixture.setup();
+    defer fixture.deinit();
+
+    const key_layer = KeymapKey.init(0, 0, 0, keycode.MO(1));
+    const key_a = KeymapKey.init(0, 1, 0, KC.A);
+    const key_trns = KeymapKey.init(1, 0, 0, KC.TRNS);
+    const key_ll = KeymapKey.init(1, 1, 0, keycode.QK_LAYER_LOCK);
+
+    fixture.setKeymap(&.{ key_layer, key_a, key_trns, key_ll });
+
+    fixture.pressKey(key_layer.row, key_layer.col);
+    fixture.runOneScanLoop();
+    try testing.expect(fixture.isLayerOn(1));
+    try testing.expect(!layer_lock.isLayerLocked(1));
+
+    fixture.pressKey(key_ll.row, key_ll.col);
+    fixture.runOneScanLoop();
+    fixture.releaseKey(key_ll.row, key_ll.col);
+    fixture.runOneScanLoop();
+    try testing.expect(fixture.isLayerOn(1));
+    try testing.expect(layer_lock.isLayerLocked(1));
+
+    fixture.releaseKey(key_layer.row, key_layer.col);
+    fixture.runOneScanLoop();
+    try testing.expect(fixture.isLayerOn(1));
+    try testing.expect(layer_lock.isLayerLocked(1));
+
+    fixture.pressKey(key_ll.row, key_ll.col);
+    fixture.runOneScanLoop();
+    try testing.expect(!fixture.isLayerOn(1));
+    try testing.expect(!layer_lock.isLayerLocked(1));
+}
+
+// ============================================================
+// 3. LayerLockLayerTapTest
+// ============================================================
+
+test "LayerLockLayerTapTest" {
+    var fixture = TestFixture.init();
+    fixture.setup();
+    defer fixture.deinit();
+
+    const key_layer = KeymapKey.init(0, 0, 0, keycode.LT(1, KC.B));
+    const key_a = KeymapKey.init(0, 1, 0, KC.A);
+    const key_trns = KeymapKey.init(1, 0, 0, KC.TRNS);
+    const key_ll = KeymapKey.init(1, 1, 0, keycode.QK_LAYER_LOCK);
+
+    fixture.setKeymap(&.{ key_layer, key_a, key_trns, key_ll });
+
+    fixture.pressKey(key_layer.row, key_layer.col);
+    fixture.idleFor(TAPPING_TERM);
+    fixture.runOneScanLoop();
+    try testing.expect(fixture.isLayerOn(1));
+
+    fixture.pressKey(key_ll.row, key_ll.col);
+    fixture.runOneScanLoop();
+    fixture.releaseKey(key_ll.row, key_ll.col);
+    fixture.runOneScanLoop();
+    try testing.expect(fixture.isLayerOn(1));
+    try testing.expect(layer_lock.isLayerLocked(1));
+
+    fixture.pressKey(key_ll.row, key_ll.col);
+    fixture.runOneScanLoop();
+    try testing.expect(!fixture.isLayerOn(1));
+    try testing.expect(!layer_lock.isLayerLocked(1));
+}
+
+// ============================================================
+// 6. LayerLockTimeoutTest
+// ============================================================
+
+test "LayerLockTimeoutTest" {
+    var fixture = TestFixture.init();
+    fixture.setup();
+    defer fixture.deinit();
+
+    layer_lock.idle_timeout = LAYER_LOCK_IDLE_TIMEOUT;
+
+    const key_layer = KeymapKey.init(0, 0, 0, keycode.MO(1));
+    const key_a = KeymapKey.init(0, 1, 0, KC.A);
+    const key_trns = KeymapKey.init(1, 0, 0, KC.TRNS);
+    const key_ll = KeymapKey.init(1, 1, 0, keycode.QK_LAYER_LOCK);
+
+    fixture.setKeymap(&.{ key_layer, key_a, key_trns, key_ll });
+
+    fixture.pressKey(key_layer.row, key_layer.col);
+    fixture.runOneScanLoop();
+    try testing.expect(fixture.isLayerOn(1));
+
+    fixture.pressKey(key_ll.row, key_ll.col);
+    fixture.runOneScanLoop();
+    fixture.releaseKey(key_ll.row, key_ll.col);
+    fixture.runOneScanLoop();
+    try testing.expect(fixture.isLayerOn(1));
+
+    fixture.releaseKey(key_layer.row, key_layer.col);
+    fixture.runOneScanLoop();
+    try testing.expect(fixture.isLayerOn(1));
+    try testing.expect(layer_lock.isLayerLocked(1));
+
+    fixture.idleFor(@intCast(LAYER_LOCK_IDLE_TIMEOUT));
+    fixture.runOneScanLoop();
+    try testing.expect(!fixture.isLayerOn(1));
+    try testing.expect(!layer_lock.isLayerLocked(1));
+}
+
+// ============================================================
+// 7. ToKeyOverridesLayerLock
+// ============================================================
+
+test "ToKeyOverridesLayerLock" {
+    var fixture = TestFixture.init();
+    fixture.setup();
+    defer fixture.deinit();
+
+    const key_layer = KeymapKey.init(0, 0, 0, keycode.MO(1));
+    const key_to0 = KeymapKey.init(1, 0, 0, keycode.TO(0));
+    const key_ll = KeymapKey.init(1, 1, 0, keycode.QK_LAYER_LOCK);
+
+    fixture.setKeymap(&.{ key_layer, key_to0, key_ll });
+
+    layer_lock.layerLockOn(1);
+    fixture.runOneScanLoop();
+    try testing.expect(fixture.isLayerOn(1));
+    try testing.expect(layer_lock.isLayerLocked(1));
+
+    fixture.pressKey(key_to0.row, key_to0.col);
+    fixture.runOneScanLoop();
+    fixture.releaseKey(key_to0.row, key_to0.col);
+    fixture.runOneScanLoop();
+    try testing.expect(!fixture.isLayerOn(1));
+    try testing.expect(!layer_lock.isLayerLocked(1));
+}
+
+// ============================================================
+// 8. LayerClearOverridesLayerLock
+// ============================================================
+
+test "LayerClearOverridesLayerLock" {
+    var fixture = TestFixture.init();
+    fixture.setup();
+    defer fixture.deinit();
+
+    const key_layer = KeymapKey.init(0, 0, 0, keycode.MO(1));
+    const key_a = KeymapKey.init(0, 1, 0, KC.A);
+    const key_ll = KeymapKey.init(1, 1, 0, keycode.QK_LAYER_LOCK);
+
+    fixture.setKeymap(&.{ key_layer, key_a, key_ll });
+
+    layer_lock.layerLockOn(1);
+    fixture.runOneScanLoop();
+    try testing.expect(fixture.isLayerOn(1));
+    try testing.expect(layer_lock.isLayerLocked(1));
+
+    fixture.layerClear();
+    fixture.pressKey(key_a.row, key_a.col);
+    fixture.runOneScanLoop();
+    try testing.expect(!fixture.isLayerOn(1));
+    try testing.expect(!layer_lock.isLayerLocked(1));
+}


### PR DESCRIPTION
## Description

C版 `tests/layer_lock/test_layer_lock.cpp` のテストケースを Zig に移植。

### 変更内容

**`src/core/layer_lock.zig`**:
- C版 API を追加: `layerLockInvert`, `layerLockOn`, `layerLockOff`, `layerLockAllOff`
- アイドルタイムアウト機能: `task()`, `activityTrigger()`, `idle_timeout`
- レイヤー状態同期: `syncWithLayerState()`
- OSL との相互作用: ロック時に `resetOneshotLayer()` を呼び出し

**`src/core/keyboard.zig`**:
- `keyboard.task()` に `layer_lock.task()` と `layer_lock.syncWithLayerState()` を追加

**`src/tests/test_layer_lock.zig`** (新規):
- LayerLockState (API テスト)
- LayerLockMomentaryTest (MO + Layer Lock)
- LayerLockLayerTapTest (LT + Layer Lock)
- LayerLockTimeoutTest (アイドルタイムアウト)
- ToKeyOverridesLayerLock (TO(0) による上書き)
- LayerClearOverridesLayerLock (layer_clear() による上書き)

**`src/main.zig`**:
- `test_layer_lock.zig` の import を追加

### 未移植テスト

C版の OSL + Layer Lock テスト (LayerLockOneshotTapTest, LayerLockOneshotHoldTest) は
タッピングパイプラインとの相互作用の調査が必要なため TODO として残している。

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Closes #157

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything