### PR TITLE
fix: Layer Lock の activityTrigger() 呼び出しタイミングをC版と合わせる

### DIFF
--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -135,6 +135,10 @@ pub fn task() void {
                     else
                         KeyEvent.keyRelease(@intCast(row), @intCast(col), time);
 
+                    // Layer Lock アクティビティトリガー:
+                    // C版 process_layer_lock() 互換で全キーイベントでタイムアウトをリセット
+                    layer_lock.activityTrigger();
+
                     // Secure プリプロセス: アンロック中はキー入力をシーケンス照合に使用
                     // C版 preprocess_secure() 互換:
                     //   press イベントはシーケンス照合に渡す（離しイベントはスキップ、
@@ -514,6 +518,67 @@ test "keyboard_task: Layer Lock がレイヤーをロックする" {
     // Layer Lock がロック中のレイヤーの layerOff をスキップする
     try testing.expect(layer_lock.isLayerLocked(1));
     try testing.expect(layer.layerStateIs(1)); // レイヤー1はまだアクティブ
+}
+
+test "keyboard_task: Layer Lock アイドルタイムアウトが他キー入力でリセットされる" {
+    _ = setup();
+    defer teardown();
+
+    const TAPPING_TERM = tapping.TAPPING_TERM;
+    const TIMEOUT: u32 = 5000;
+
+    // Layer 0: (0,0) = MO(1), (0,1) = KC_A
+    // Layer 1: (0,1) = QK_LLCK, (0,2) = KC_B
+    test_keymap[0][0][0] = keycode.MO(1);
+    test_keymap[0][0][1] = keycode.KC.A;
+    test_keymap[1][0][1] = keycode.QK_LLCK;
+    test_keymap[1][0][2] = keycode.KC.B;
+
+    // アイドルタイムアウトを設定
+    layer_lock.idle_timeout = TIMEOUT;
+
+    // MO(1) を押してホールド確定
+    pressKey(0, 0);
+    task();
+    timer.mockAdvance(TAPPING_TERM + 1);
+    task();
+    try testing.expect(layer.layerStateIs(1));
+
+    // Layer Lock を押してレイヤー1をロック
+    pressKey(0, 1);
+    task();
+    try testing.expect(layer_lock.isLayerLocked(1));
+    releaseKey(0, 1);
+    task();
+
+    // MO(1) を離す（ロック中なのでレイヤー1は維持）
+    releaseKey(0, 0);
+    task();
+    try testing.expect(layer_lock.isLayerLocked(1));
+    try testing.expect(layer.layerStateIs(1));
+
+    // タイムアウトの半分経過
+    timer.mockAdvance(TIMEOUT / 2);
+    task();
+    try testing.expect(layer_lock.isLayerLocked(1)); // まだロック中
+
+    // 別のキーを押す -> activityTrigger によりタイマーリセット
+    pressKey(0, 2);
+    task();
+    releaseKey(0, 2);
+    task();
+
+    // さらにタイムアウトの半分+少し経過（リセットされなければタイムアウト超過）
+    timer.mockAdvance(TIMEOUT / 2 + 100);
+    task();
+    // activityTrigger でリセットされているので、まだロック中のはず
+    try testing.expect(layer_lock.isLayerLocked(1));
+    try testing.expect(layer.layerStateIs(1));
+
+    // さらにタイムアウト分経過 → タイムアウトでロック解除
+    timer.mockAdvance(TIMEOUT);
+    task();
+    try testing.expect(!layer_lock.isLayerLocked(1));
 }
 
 test "keyboard_task: Tri Layer — Lower+Upper で Adjust が有効になる" {

--- a/src/core/layer_lock.zig
+++ b/src/core/layer_lock.zig
@@ -97,7 +97,7 @@ pub fn task() void {
     }
 }
 
-/// アクティビティトリガー（ロック操作時にタイマーリセット）
+/// アクティビティトリガー（任意のキー入力でタイマーリセット）
 pub fn activityTrigger() void {
     lock_timer = timer.read32();
 }


### PR DESCRIPTION
## Description

C版 `process_layer_lock()` では全キーイベントで `layer_lock_activity_trigger()` を呼び、任意のキー入力でアイドルタイムアウトをリセットしていた。Zig版ではロック操作時（`processLayerLock()` の lock ブランチ、`layerLockInvert()` の lock ブランチ）のみ呼んでいたため、C版の仕様が再現されていなかった。

### 変更内容

- `keyboard.task()` のキーイベント処理ループ内で `layer_lock.activityTrigger()` を全キーイベントで呼ぶように修正
- `layer_lock.zig` の `activityTrigger()` のコメントを実態に合わせて更新
- アイドルタイムアウトが他キー入力でリセットされることを検証するテストを追加

## Types of Changes

- [x] Bugfix

## Issues Fixed or Closed by This PR

* Fixes #192

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).