### PR TITLE
fix: Repeat Key のローリングプレスでキースタック防止と中間レポート検証追加

### DIFF
--- a/src/core/repeat_key.zig
+++ b/src/core/repeat_key.zig
@@ -35,22 +35,30 @@ pub fn getLastMods() u8 {
     return last_mods;
 }
 
+/// press 時に登録したキーコード・修飾キーを保持する（C版 registered_record 相当）
+/// ローリングプレスで last_keycode が変わってもキースタックを防ぐ
+var registered_keycode: u8 = 0;
+var registered_mods: u8 = 0;
+
 /// Repeat Key が押されたときの処理
 /// 直前に記録されたキーコードを送信する
 pub fn processRepeatKey(pressed: bool) void {
     if (last_keycode == 0) return;
 
     if (pressed) {
+        // press 時のキーコード・修飾キーを保存（release 時に使用）
+        registered_keycode = last_keycode;
+        registered_mods = last_mods;
         // 直前のキーの修飾キーを一時的に適用
-        if (last_mods != 0) {
-            host.addWeakMods(last_mods);
+        if (registered_mods != 0) {
+            host.addWeakMods(registered_mods);
         }
-        host.registerCode(last_keycode);
+        host.registerCode(registered_keycode);
         host.sendKeyboardReport();
     } else {
-        host.unregisterCode(last_keycode);
-        if (last_mods != 0) {
-            host.delWeakMods(last_mods);
+        host.unregisterCode(registered_keycode);
+        if (registered_mods != 0) {
+            host.delWeakMods(registered_mods);
         }
         host.sendKeyboardReport();
     }
@@ -60,6 +68,8 @@ pub fn processRepeatKey(pressed: bool) void {
 pub fn reset() void {
     last_keycode = 0;
     last_mods = 0;
+    registered_keycode = 0;
+    registered_mods = 0;
 }
 
 // ============================================================

--- a/src/tests/test_repeat_key.zig
+++ b/src/tests/test_repeat_key.zig
@@ -273,6 +273,10 @@ test "RepeatKey: RollingFromRepeat - rolling press from repeat to key" {
     // Repeat を離す（KC_A が unregister される）
     fixture.releaseKey(0, 2);
     fixture.runOneScanLoop();
+    // C版 InSequence: EXPECT_REPORT(driver, (KC_B)) に相当
+    // KC_A が unregister され、KC_B のみのレポートになること
+    try testing.expect(fixture.driver.lastKeyboardReport().hasKey(KC.B));
+    try testing.expect(!fixture.driver.lastKeyboardReport().hasKey(KC.A));
 
     // B を離す
     fixture.releaseKey(0, 1);


### PR DESCRIPTION
## Description

C版 `repeat_key_invoke()` は press 時のキーレコードを static 変数 `registered_record` に保存し、release 時にそのレコードを使用してキーの unregister を行う。これにより、ローリングプレス中に `last_keycode` が別キーに更新されても、release 時に正しいキーが unregister される。

Zig版では `last_keycode` を直接参照していたため、ローリングプレス（Repeat 押下中に別キーを押す）で `last_keycode` が別キーに更新されると、release 時に誤ったキーが unregister され、元のキーがスタック（押しっぱなし）状態になっていた。

### 変更内容

- `repeat_key.zig`: `registered_keycode` / `registered_mods` を追加し、press 時のキーコード・修飾キーを保持。release 時にはこの保存値を使用
- `test_repeat_key.zig`: RollingFromRepeat テストに Repeat release 後の中間レポート検証を追加（C版 InSequence の `EXPECT_REPORT(driver, (KC_B))` に相当）

## Types of Changes

- [x] Bugfix

## Issues Fixed or Closed by This PR

* Fixes #191

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).