### PR TITLE
fix: Tap Dance に interrupted フラグを追加し Double single tap に対応

### DIFF
--- a/src/core/tap_dance.zig
+++ b/src/core/tap_dance.zig
@@ -36,14 +36,13 @@ pub const TapDanceAction = struct {
 };
 
 /// Tap Dance の状態
-/// 注意: C版には `interrupted` フィールドがあるが、Zig版では簡略化のため省略。
-/// C版では割り込み時にホールド中でも `on_tap` を選ぶ場合があるが、
-/// Zig版では `pressed` のみで判断する（ホールド中は常に `on_hold`）。
 pub const TapDanceState = struct {
     /// タップ回数
     count: u8 = 0,
     /// 現在押下中か
     pressed: bool = false,
+    /// 他のキーによって割り込まれたか（C版 interrupted フラグ相当）
+    interrupted: bool = false,
     /// ダンス確定済みか
     finished: bool = false,
     /// 使用中か
@@ -124,6 +123,7 @@ pub fn preprocess(keycode: Keycode, pressed: bool) bool {
     if (td_index >= actions.len) return false;
 
     const state = getState(td_index) orelse return false;
+    state.interrupted = true;
     finishDance(td_index, state);
 
     return true;
@@ -180,17 +180,36 @@ fn finishDance(td_index: u8, state: *TapDanceState) void {
     const td_action = actions[td_index];
 
     // タップ数と押下状態に応じてアクションを決定
-    const kc: Keycode = if (state.pressed) blk: {
-        // ホールド中
-        break :blk if (state.count >= 2) td_action.on_tap_hold else td_action.on_hold;
-    } else blk: {
-        // リリース済み（タップ）
-        break :blk if (state.count >= 2) td_action.on_double_tap else td_action.on_tap;
-    };
+    // C版の interrupted フラグ: count >= 2 かつ interrupted かつ !pressed の場合は
+    // 「ダブルシングルタップ」として、on_tap を count 回独立送信する
+    if (state.count >= 2 and state.interrupted and !state.pressed) {
+        // ダブルシングルタップ: on_tap を (count-1) 回 tap_code + 1回 register_code
+        const tap_kc = td_action.on_tap;
+        // 先行タップ分を tap_code 相当で送信（register → send → unregister → send）
+        var i: u8 = 0;
+        while (i < state.count - 1) : (i += 1) {
+            registerKeycode(tap_kc);
+            host.sendKeyboardReport();
+            unregisterKeycode(tap_kc);
+            host.sendKeyboardReport();
+        }
+        // 最後の1回は register のみ（リリース時に unregister される）
+        state.registered_kc = tap_kc;
+        registerKeycode(tap_kc);
+        host.sendKeyboardReport();
+    } else {
+        const kc: Keycode = if (state.pressed) blk: {
+            // ホールド中
+            break :blk if (state.count >= 2) td_action.on_tap_hold else td_action.on_hold;
+        } else blk: {
+            // リリース済み（タップ）
+            break :blk if (state.count >= 2) td_action.on_double_tap else td_action.on_tap;
+        };
 
-    state.registered_kc = kc;
-    registerKeycode(kc);
-    host.sendKeyboardReport();
+        state.registered_kc = kc;
+        registerKeycode(kc);
+        host.sendKeyboardReport();
+    }
 
     active_td = 0;
 

--- a/src/tests/test_tap_dance.zig
+++ b/src/tests/test_tap_dance.zig
@@ -348,3 +348,64 @@ test "QuadFunction_double_hold" {
     _ = tap_dance.process(td_kc, false);
     try testing.expect(driver.lastKeyboardReport().isEmpty());
 }
+
+// ============================================================
+// C版 QuadFunction "Double single tap" の移植
+// tap_key(key_quad); tap_key(key_quad); regular_key.press() で
+// 2回の独立シングルタップ（各々 KC_X）が送信される
+// ============================================================
+
+test "QuadFunction_double_single_tap" {
+    const driver = setupTest();
+    defer teardownTest();
+
+    const actions = [_]tap_dance.TapDanceAction{
+        .{ .on_tap = KC.X, .on_hold = KC.LEFT_CTRL, .on_double_tap = KC.ESCAPE, .on_tap_hold = KC.LEFT_ALT },
+    };
+    tap_dance.setActions(&actions);
+
+    const td_kc = keycode_mod.TD(0);
+
+    // 1st tap
+    _ = tap_dance.process(td_kc, true);
+    timer.mockAdvance(1);
+    _ = tap_dance.process(td_kc, false);
+
+    // 2nd tap
+    timer.mockAdvance(50);
+    _ = tap_dance.process(td_kc, true);
+    timer.mockAdvance(1);
+    _ = tap_dance.process(td_kc, false);
+
+    // 別キーで割り込み → ダブルシングルタップとして確定
+    timer.mockAdvance(5);
+    _ = tap_dance.preprocess(KC.A, true);
+
+    // C版期待値:
+    //   EXPECT_REPORT(driver, (KC_X));      -- 1回目シングルタップ
+    //   EXPECT_EMPTY_REPORT(driver);
+    //   EXPECT_REPORT(driver, (KC_X));      -- 2回目シングルタップ
+    //   EXPECT_EMPTY_REPORT(driver);
+
+    // レポートが4件以上あること（X押下、空、X押下、空）
+    try testing.expect(driver.keyboard_count >= 4);
+
+    // 1つ目: KC_X あり
+    try testing.expect(driver.keyboard_reports[0].hasKey(KC.X));
+    // 2つ目: 空レポート
+    try testing.expect(driver.keyboard_reports[1].isEmpty());
+    // 3つ目: KC_X あり
+    try testing.expect(driver.keyboard_reports[2].hasKey(KC.X));
+    // 4つ目: 空レポート（unregisterAndReset で送信される）
+    try testing.expect(driver.keyboard_reports[3].isEmpty());
+
+    // ESC（on_double_tap）は送信されていないこと
+    var found_esc = false;
+    for (0..@min(driver.keyboard_count, 64)) |i| {
+        if (driver.keyboard_reports[i].hasKey(KC.ESCAPE)) {
+            found_esc = true;
+            break;
+        }
+    }
+    try testing.expect(!found_esc);
+}


### PR DESCRIPTION
## Description

C版の `tap_dance_state_t.interrupted` フラグに相当する機能を Zig版の `TapDanceState` に追加した。

C版では Tap Dance キーを2回タップした後に別のキーで割り込まれた場合、`cur_dance()` が `TD_DOUBLE_SINGLE_TAP` を返し、`on_double_tap` ではなく `on_tap` を2回独立して送信する。Zig版にはこの `interrupted` フラグがなかったため、同じ状況で `on_double_tap` が使われていた。

### 変更内容

- `TapDanceState` に `interrupted: bool` フィールドを追加
- `preprocess()` で別キー割り込み時に `interrupted = true` を設定
- `finishDance()` で `count >= 2` かつ `interrupted` かつ `!pressed` の場合に「ダブルシングルタップ」として `on_tap` を `count` 回独立送信する処理を追加
- C版 `tests/tap_dance/test_examples.cpp` の QuadFunction "Double single tap" テストケースを移植

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* #190

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).