### PR TITLE
chore: action.zig OP_ONESHOT デッドコード除去

### DIFF
--- a/src/core/action.zig
+++ b/src/core/action.zig
@@ -615,18 +615,10 @@ fn processLayerTapSpecial(keyp: *KeyRecord, l: u5, code: u8) void {
         },
         OP_ONESHOT => {
             // One-Shot Layer (OSL)
-            // C版: #if !defined(NO_ACTION_ONESHOT) && !defined(NO_ACTION_TAPPING)
-            // NO_ACTION_TAPPING 有効時は oneshot 動作を無効化し、
-            // 単純な MO (layer_on/layer_off) として動作する
-            if (action_code.no_action_tapping) {
-                if (ev.pressed) {
-                    layer.layerOn(l);
-                } else {
-                    layer.layerOff(l);
-                }
-            } else {
-                processOneShotLayerAction(keyp, l);
-            }
+            // no_action_tapping=true の場合、keycodeToAction で OSL は
+            // ACTION_LAYER_MOMENTARY (OP_ON_OFF) に変換されるため、
+            // OP_ONESHOT に到達する時点で常に oneshot 動作が有効
+            processOneShotLayerAction(keyp, l);
         },
         else => {},
     }


### PR DESCRIPTION
## Description

`src/core/action.zig` の `processLayerTapSpecial` 関数内、`OP_ONESHOT` ブランチにある `no_action_tapping` 分岐はデッドコードであるため削除した。

`keycodeToAction`（`action_code.zig:425-429`）において `no_action_tapping=true` の場合、OSL キーコードは `ACTION_LAYER_MOMENTARY`（`OP_ON_OFF`）に変換されるため、`OP_ONESHOT` ケースに `no_action_tapping=true` で到達することはない。

到達不可能な分岐を削除し、直接 `processOneShotLayerAction` を呼び出すよう簡潔にした。

## Types of Changes

- [x] Core

## Issues Fixed or Closed by This PR

* Closes #201

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).