### PR TITLE
refactor: main.zig キーボード選択ロジック重複を解消

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -83,10 +83,7 @@ pub const startup = if (is_freestanding) struct {
     const keyboard = @import("core/keyboard.zig");
     const action_mod = @import("core/action.zig");
     const host_mod = @import("core/host.zig");
-    const kb_mod = if (std.mem.eql(u8, @import("build_options").KEYBOARD, "madbd34"))
-        @import("keyboards/madbd34.zig")
-    else
-        @import("keyboards/madbd5.zig");
+    const kb_mod = @import("root").kb;
 
     const MatrixType = matrix_mod.Matrix(kb_mod.rows, kb_mod.cols);
 


### PR DESCRIPTION
## Description

`src/main.zig` のトップレベル `pub const kb`（12行目）と `startup` struct 内の `const kb_mod`（86行目）で、同一の `build_options.KEYBOARD` 比較ロジックが重複していた問題を解消。

Zig ではネストされた struct 内部から外部スコープの宣言に直接アクセスできないため、`startup` struct 内で `@import("root").kb` を使用してトップレベルの `kb` 定数を参照するように変更した。

これにより、将来キーボードを追加する際に片方の更新を忘れるリスクを排除した。

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #202

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the PR Checklist document and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).