### PR TITLE
fix: flash.zig の Zig 0.15.2 互換性を修正

### DIFF
--- a/tools/flash.zig
+++ b/tools/flash.zig
@@ -19,7 +19,6 @@ const BOOTSEL_VOLUME_NAME = "RPI-RP2";
 
 pub fn main() !void {
     const allocator = std.heap.page_allocator;
-    const stdout = std.io.getStdOut().writer();
 
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
@@ -57,7 +56,7 @@ pub fn main() !void {
     };
     defer allocator.free(bootsel_path);
 
-    try stdout.print("RP2040 BOOTSEL ドライブを検出: {s}\n", .{bootsel_path});
+    std.debug.print("RP2040 BOOTSEL ドライブを検出: {s}\n", .{bootsel_path});
 
     // Copy UF2 file to BOOTSEL drive
     const dest_path = std.fs.path.join(allocator, &.{ bootsel_path, std.fs.path.basename(uf2_path) }) catch {
@@ -65,14 +64,14 @@ pub fn main() !void {
     };
     defer allocator.free(dest_path);
 
-    try stdout.print("フラッシュ中: {s} -> {s}\n", .{ uf2_path, dest_path });
+    std.debug.print("フラッシュ中: {s} -> {s}\n", .{ uf2_path, dest_path });
 
     std.fs.cwd().copyFile(uf2_path, std.fs.cwd(), dest_path, .{}) catch |err| {
         std.debug.print("Error: UF2 ファイルのコピーに失敗しました: {}\n", .{err});
         return error.CopyFailed;
     };
 
-    try stdout.print("フラッシュ完了。RP2040 が自動的に再起動します。\n", .{});
+    std.debug.print("フラッシュ完了。RP2040 が自動的に再起動します。\n", .{});
 }
 
 fn detectBootselDrive(allocator: std.mem.Allocator) ![]const u8 {


### PR DESCRIPTION
## Description

`tools/flash.zig` で使用していた `std.io.getStdOut().writer()` が Zig 0.15.2 で削除されたため、コンパイルエラーが発生していた。

ステータスメッセージの出力を `std.debug.print()` に置換して修正。

## Types of Changes

- [x] Bugfix

## Issues Fixed or Closed by This PR

*

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).