### PR TITLE
feat: flash ツールに BOOTSEL ドライブ待機機能を追加

### DIFF
--- a/tools/flash.zig
+++ b/tools/flash.zig
@@ -38,7 +38,7 @@ pub fn main() !void {
 
     // Detect BOOTSEL drive (wait for it if not found)
     const bootsel_path = detectBootselDrive(allocator) catch |err| switch (err) {
-        error.BootselNotFound => waitForBootselDrive(allocator) catch |e| return e,
+        error.BootselNotFound => try waitForBootselDrive(allocator),
         else => return err,
     };
     defer allocator.free(bootsel_path);


### PR DESCRIPTION
## Description

`zig build flash` 実行時、BOOTSELドライブが未検出だと即エラーで終了していたため、コマンド実行前にキーボードをBOOTSELモードにしておく必要があった。

BOOTSELドライブ未検出時に60秒間ポーリングで待機するように変更し、コマンド実行後にキーボードをBOOTSELモードで接続できるようにした。

### 変更内容
- `waitForBootselDrive()`: 0.5秒間隔で最大60秒間ドライブ出現を待機
- 待機中は案内メッセージを表示

## Types of Changes

- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

*

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).