### PR TITLE
fix: Zig 0.15.2 で std.time.sleep を std.Thread.sleep に修正

### DIFF
--- a/tools/flash.zig
+++ b/tools/flash.zig
@@ -73,7 +73,7 @@ fn waitForBootselDrive(allocator: std.mem.Allocator) ![]const u8 {
     , .{timeout_seconds});
 
     for (0..timeout_seconds * std.time.ms_per_s / poll_interval_ms) |_| {
-        std.time.sleep(poll_interval_ms * std.time.ns_per_ms);
+        std.Thread.sleep(poll_interval_ms * std.time.ns_per_ms);
         if (detectBootselDrive(allocator)) |path| {
             return path;
         } else |err| {


### PR DESCRIPTION
## Description

Zig 0.15.2 で `std.time.sleep` が削除され `std.Thread.sleep` に移行されたため、`tools/flash.zig` のポーリング待機で使用している `sleep` 呼び出しを修正。

## Types of Changes

- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).