### PR TITLE
fix: EP1-EP3 エンドポイント制御レジスタの初期化を実装

### DIFF
--- a/src/hal/usb.zig
+++ b/src/hal/usb.zig
@@ -455,27 +455,25 @@ pub const UsbDriver = struct {
     /// Sets endpoint type (Interrupt), buffer address, and interrupt-per-buffer for each IN endpoint.
     fn hwConfigureEndpoints(self: *UsbDriver) void {
         _ = self;
-        const endpoints = [_]struct { ep: u8, size: u8 }{
-            .{ .ep = usb_descriptors.KEYBOARD_ENDPOINT, .size = usb_descriptors.KEYBOARD_ENDPOINT_SIZE },
-            .{ .ep = usb_descriptors.MOUSE_ENDPOINT, .size = usb_descriptors.MOUSE_ENDPOINT_SIZE },
-            .{ .ep = usb_descriptors.EXTRA_ENDPOINT, .size = usb_descriptors.EXTRA_ENDPOINT_SIZE },
+        const endpoints = [_]u8{
+            usb_descriptors.KEYBOARD_ENDPOINT,
+            usb_descriptors.MOUSE_ENDPOINT,
+            usb_descriptors.EXTRA_ENDPOINT,
         };
 
-        for (endpoints) |entry| {
+        for (endpoints) |ep| {
             // EP control register address: EP_IN_CTRL_BASE + (ep - 1) * 8
             // EP0 has no control register; EP1 starts at offset 0x08
-            const ctrl_addr = USBCTRL_DPRAM_BASE + DPRAM.EP_IN_CTRL_BASE + (@as(u32, entry.ep) - 1) * 8;
+            const ctrl_addr = USBCTRL_DPRAM_BASE + DPRAM.EP_IN_CTRL_BASE + (@as(u32, ep) - 1) * 8;
             const ctrl_reg = @as(*volatile u32, @ptrFromInt(ctrl_addr));
 
             // Buffer address in DPRAM (relative to DPRAM base): EP_BUF_BASE + (ep - 1) * 64
-            const buf_offset = DPRAM.EP_BUF_BASE + (@as(u32, entry.ep) - 1) * 64;
+            const buf_offset = DPRAM.EP_BUF_BASE + (@as(u32, ep) - 1) * 64;
 
             ctrl_reg.* = EpCtrl.ENABLE |
                 EpCtrl.INTERRUPT_PER_BUFF |
                 EpCtrl.EP_TYPE_INTERRUPT |
                 (buf_offset & EpCtrl.BUFFER_ADDRESS_MASK);
-
-            _ = entry.size;
         }
     }
 


### PR DESCRIPTION
## Description

SET_CONFIGURATION処理時にEP1-EP3のINエンドポイント制御レジスタに以下を設定する処理を実装:

1. エンドポイントタイプ (Interrupt)
2. バッファアドレス（DPRAM内のオフセット）
3. 割り込み per バッファ完了
4. エンドポイント有効化

また、`hwSendEndpoint()`のバッファアドレス計算を`(ep-1)*64`に修正し、エンドポイント制御レジスタで設定されるアドレスと整合させた。

### 変更概要
- `EpCtrl` 定数構造体を追加（エンドポイント制御レジスタのビットフィールド定義）
- `hwConfigureEndpoints()` 関数を追加（EP1-EP3のINエンドポイント制御レジスタを初期化）
- `handleStandardRequest()` の SET_CONFIGURATION 処理から `hwConfigureEndpoints()` を呼び出し
- `hwSendEndpoint()` のバッファアドレス計算を `EP_BUF_BASE + (ep-1)*64` に修正
- テスト追加: EpCtrl ビット位置、バッファオフセット整合性、制御レジスタDPRAMオフセット

## Types of Changes

- [x] Bugfix

## Issues Fixed or Closed by This PR

* Closes #222

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).