### PR TITLE
fix: コントロール転送のステータスステージ ZLP 送信を実装

### DIFF
--- a/src/hal/usb.zig
+++ b/src/hal/usb.zig
@@ -451,10 +451,10 @@ pub const UsbDriver = struct {
     /// Send a zero-length packet (ZLP) on EP0 IN for the status stage of a control transfer.
     /// USB 2.0 spec requires a status stage ZLP after processing host-to-device requests
     /// (SET_ADDRESS, SET_CONFIGURATION, SET_IDLE, SET_PROTOCOL, SET_REPORT).
-    pub fn sendStatusStageZlp(self: *UsbDriver) void {
+    fn sendStatusStageZlp(self: *UsbDriver) void {
         if (is_freestanding) {
             const buf_ctrl = @as(*volatile u32, @ptrFromInt(USBCTRL_DPRAM_BASE + DPRAM.EP_BUF_CTRL_BASE));
-            var ctrl: u32 = BufCtrl.FULL | BufCtrl.AVAILABLE;
+            var ctrl: u32 = BufCtrl.FULL | BufCtrl.LAST | BufCtrl.AVAILABLE;
             if (self.data_toggle[0]) {
                 ctrl |= BufCtrl.DATA_PID;
             }
@@ -1316,6 +1316,24 @@ test "SET_PROTOCOL sends status stage ZLP" {
     });
 
     try testing.expectEqual(HidProtocol.boot, drv.keyboard_protocol);
+    // Data toggle flipped by ZLP
+    try testing.expect(drv.data_toggle[0] == true);
+}
+
+test "SET_REPORT sends status stage ZLP" {
+    var drv = UsbDriver{};
+    drv.init();
+
+    drv.mock_ep0_out_data = 0x03; // NumLock + CapsLock
+    drv.handleSetup(&.{
+        .bmRequestType = 0x21,
+        .bRequest = HidRequest.SET_REPORT,
+        .wValue = 0x0200, // Output report, ID 0
+        .wIndex = usb_descriptors.KEYBOARD_INTERFACE,
+        .wLength = 1,
+    });
+
+    try testing.expectEqual(@as(u8, 0x03), drv.keyboard_leds);
     // Data toggle flipped by ZLP
     try testing.expect(drv.data_toggle[0] == true);
 }


### PR DESCRIPTION
## Description

USB 2.0仕様に準拠し、ホストからのコントロールリクエスト処理後にEP0 INにゼロ長パケット（ZLP）を送信するステータスステージを実装。

### 変更概要
- `sendStatusStageZlp()` 関数を追加（EP0 INバッファに長さ0のパケットを送信）
- `SET_ADDRESS`, `SET_CONFIGURATION`, `SET_IDLE`, `SET_PROTOCOL`, `SET_REPORT` の各処理後にZLPを送信
- `SET_ADDRESS` ではアドレスを `pending_address` に一時保存し、ZLP完了後（BUFF_STATUS EP0 IN完了イベント）にハードウェアに適用（USB 2.0仕様: ステータスステージ完了後にアドレス変更）
- `handleBusReset` で `pending_address` をクリア
- テスト7件追加

## Types of Changes

- [x] Bugfix

## Issues Fixed or Closed by This PR

* Closes #221

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).