### PR TITLE
fix: SET_REPORT EP0 OUT バッファアドレスを修正

### DIFF
--- a/src/hal/usb.zig
+++ b/src/hal/usb.zig
@@ -67,7 +67,7 @@ pub const DPRAM = struct {
     pub const EP_IN_CTRL_BASE: u32 = 0x08;
     pub const EP_OUT_CTRL_BASE: u32 = 0x0C;
     pub const EP_BUF_CTRL_BASE: u32 = 0x80;
-    pub const EP0_IN_BUF: u32 = 0x100;
+    pub const EP0_BUF: u32 = 0x100; // ep0_buf_a: EP0 data stage buffer (IN/OUT shared)
     pub const EP0_OUT_BUF: u32 = 0x140;
     pub const EP_BUF_BASE: u32 = 0x180;
 };
@@ -341,7 +341,7 @@ pub const UsbDriver = struct {
                 // not in wValue. wValue contains (ReportType << 8 | ReportID).
                 if (is_freestanding) {
                     // Read LED byte from EP0 OUT data buffer
-                    const ep0_buf = @as(*volatile u8, @ptrFromInt(USBCTRL_DPRAM_BASE + DPRAM.EP_BUF_BASE));
+                    const ep0_buf = @as(*volatile u8, @ptrFromInt(USBCTRL_DPRAM_BASE + DPRAM.EP0_BUF));
                     self.keyboard_leds = ep0_buf.*;
                 } else {
                     // Mock: use ep0_out_data if set, otherwise no-op
@@ -411,7 +411,7 @@ pub const UsbDriver = struct {
         const is_last = (offset + chunk_len) >= total;
 
         if (is_freestanding) {
-            const ep0_buf = @as([*]volatile u8, @ptrFromInt(USBCTRL_DPRAM_BASE + DPRAM.EP0_IN_BUF));
+            const ep0_buf = @as([*]volatile u8, @ptrFromInt(USBCTRL_DPRAM_BASE + DPRAM.EP0_BUF));
             for (0..chunk_len) |i| {
                 ep0_buf[i] = data[offset + i];
             }
@@ -907,6 +907,15 @@ test "EP buffer offsets are consistent between hwConfigureEndpoints and hwSendEn
     // Buffers must not overlap (each is 64 bytes)
     try testing.expect(ep2_offset >= ep1_offset + 64);
     try testing.expect(ep3_offset >= ep2_offset + 64);
+}
+
+test "EP0 data buffer address is correct" {
+    // EP0 data buffer (ep0_buf_a) is at DPRAM offset 0x100
+    // This is used for both GET_DESCRIPTOR (IN) and SET_REPORT (OUT) data stages.
+    try testing.expectEqual(@as(u32, 0x100), DPRAM.EP0_BUF);
+    // EP0_BUF must not overlap with EP1+ buffers
+    try testing.expect(DPRAM.EP0_BUF + 64 <= DPRAM.EP0_OUT_BUF);
+    try testing.expect(DPRAM.EP0_OUT_BUF + 64 <= DPRAM.EP_BUF_BASE);
 }
 
 test "EP control register DPRAM offsets" {


### PR DESCRIPTION
## Description

SET_REPORT 処理でホストからの LED データを読む際、EP1+ データバッファ (`EP_BUF_BASE = 0x180`) を参照していたが、正しくは EP0 データステージバッファ (`ep0_buf_a = 0x100`) を参照すべきだった。

pico-sdk では EP0 のデータステージに `USB_DPRAM->ep0_buf_a`（DPRAM offset 0x100）を使用する。`EP_BUF_BASE`（0x180）は EP1 以降のデータバッファ領域であり、EP0 OUT のデータは格納されない。

### 変更内容

- `DPRAM.EP0_IN_BUF` を `DPRAM.EP0_BUF` にリネーム（IN/OUT 共用バッファの実態を反映）
- `handleClassRequest` の SET_REPORT 処理で `EP_BUF_BASE`(0x180) を `EP0_BUF`(0x100) に修正
- GET_DESCRIPTOR 処理の参照も `EP0_BUF` に統一
- EP0 バッファアドレス検証テストを追加

## Types of Changes

- [x] Bugfix

## Issues Fixed or Closed by This PR

* Closes #226

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).