### PR TITLE
chore: トートロジーなテストを削除

### DIFF
--- a/src/hal/usb.zig
+++ b/src/hal/usb.zig
@@ -1396,8 +1396,3 @@ test "handleBuffStatus applies pending_address after ZLP" {
     // pending_address should be consumed
     try testing.expect(drv.pending_address == null);
 }
-
-test "EP0 OUT BUF CTRL address" {
-    // EP0 OUT BUF CTRL: DPRAM base + EP_BUF_CTRL_BASE + 4 = 0x84
-    try testing.expectEqual(USBCTRL_DPRAM_BASE + 0x84, BufCtrl.EP0_OUT_ADDR);
-}


### PR DESCRIPTION
## Description

PR #234 のレビューで指摘された `EP0 OUT BUF CTRL address` テストのトートロジーを解消するため、該当テストを削除する。

`BufCtrl.EP0_OUT_ADDR` は `USBCTRL_DPRAM_BASE + DPRAM.EP_BUF_CTRL_BASE + 4` と定義されており、テストは `USBCTRL_DPRAM_BASE + 0x84 == USBCTRL_DPRAM_BASE + 0x80 + 4` という自明な等式を確認しているだけで、テストとしての意義が薄い。

## Types of Changes

- [x] Core

## Issues Fixed or Closed by This PR

* Closes #236

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).