### PR TITLE
feat: ブートシーケンスログとビルド時ファイルサイズ表示を追加

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -61,7 +61,6 @@ pub fn build(b: *std.Build) void {
     const elf_name = b.fmt("{s}_{s}", .{ keyboard, keymap });
     const elf_size_step = addFileSizeStep(b, b.getInstallPath(.bin, elf_name), elf_name);
     elf_size_step.dependOn(&install_firmware.step);
-    b.getInstallStep().dependOn(&install_firmware.step);
     b.getInstallStep().dependOn(elf_size_step);
 
     // Optional boot2 binary path (required for booting on real hardware)

--- a/src/main.zig
+++ b/src/main.zig
@@ -104,6 +104,8 @@ pub const startup = if (is_freestanding) struct {
         // UART0 デバッグ出力初期化（GP0 = TX, 115200bps, 8N1）
         uart.init();
 
+        // 注: clock/gpio は UART 初期化前に完了しているが、UART が使用可能になった
+        // この時点でまとめて出力する。clock/gpio でハングした場合はこれらも出力されない。
         uart.print("[BOOT] clock.init() done\n", .{});
         uart.print("[BOOT] gpio.init() done\n", .{});
         uart.print("[BOOT] uart.init() done\n", .{});


### PR DESCRIPTION
## Description

ファームウェアの起動シーケンス各段階で UART デバッグログを出力し、実機デバッグ時にどの初期化ステップまで到達したか確認可能にする。また、ビルド時にファームウェアのファイルサイズをコンソールに表示する。

### main.zig: ブートログ

初期化各ステップ完了後に `[BOOT]` プレフィックス付きメッセージを UART 出力:

```
[BOOT] clock.init() done
[BOOT] gpio.init() done
[BOOT] uart.init() done
[BOOT] matrix.init() done
[BOOT] usb.init() done
[BOOT] eeprom.init() done
[BOOT] keyboard.init() done
[BOOT] madbd5 firmware ready, entering main loop
```

### build.zig: ファイルサイズ表示

カスタム `FileSizeStep` を追加し、ビルド完了時にファイルサイズを表示:

- `zig build`: ELF ファイルサイズ表示（例: `madbd5_default: 1760.9 KB (1803144 bytes)`）
- `zig build uf2`: UF2 ファイルサイズ表示
- `zig build flash`: UF2 ファイルサイズ表示 + フラッシュ実行

## Types of Changes

- [x] Core
- [x] New feature
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* #247 の追加対応（ブートログ強化 + ビルド情報表示）

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **PR Checklist** document and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).