### PR TITLE
fix: SET_CONFIGURATION 時にエンドポイントの data_toggle をリセット

### DIFF
--- a/src/hal/usb.zig
+++ b/src/hal/usb.zig
@@ -314,13 +314,13 @@ pub const UsbDriver = struct {
             },
             Request.SET_CONFIGURATION => {
                 self.configuration = @truncate(setup.wValue);
+                // Reset data toggle for EP1-EP3 to DATA0 (USB 2.0 spec §9.4.7:
+                // data toggle bits for all endpoints shall be reset on SET_CONFIGURATION)
+                self.data_toggle[1] = false;
+                self.data_toggle[2] = false;
+                self.data_toggle[3] = false;
                 if (self.configuration > 0) {
                     self.state = .configured;
-                    // Reset data toggle for EP1-EP3 to DATA0 (USB 2.0 spec requires
-                    // data toggle reset on SET_CONFIGURATION)
-                    self.data_toggle[1] = false;
-                    self.data_toggle[2] = false;
-                    self.data_toggle[3] = false;
                     if (is_freestanding) {
                         self.hwConfigureEndpoints();
                     }
@@ -1454,6 +1454,37 @@ test "SET_CONFIGURATION re-configuration resets EP1-EP3 data toggle" {
 
     try testing.expectEqual(DeviceState.configured, drv.state);
     // EP1-EP3 data toggles should be reset again
+    try testing.expectEqual(false, drv.data_toggle[1]);
+    try testing.expectEqual(false, drv.data_toggle[2]);
+    try testing.expectEqual(false, drv.data_toggle[3]);
+}
+
+test "SET_CONFIGURATION with value 0 also resets EP1-EP3 data toggle" {
+    var drv = UsbDriver{};
+    drv.init();
+
+    // First configure
+    drv.handleSetup(&.{
+        .bmRequestType = 0x00,
+        .bRequest = Request.SET_CONFIGURATION,
+        .wValue = 1,
+    });
+    try testing.expectEqual(DeviceState.configured, drv.state);
+
+    // Simulate data toggle activity
+    drv.data_toggle[1] = true;
+    drv.data_toggle[2] = true;
+    drv.data_toggle[3] = true;
+
+    // De-configure (SET_CONFIGURATION with value 0)
+    drv.handleSetup(&.{
+        .bmRequestType = 0x00,
+        .bRequest = Request.SET_CONFIGURATION,
+        .wValue = 0,
+    });
+
+    try testing.expectEqual(DeviceState.addressed, drv.state);
+    // EP1-EP3 data toggles should be reset even with configuration 0
     try testing.expectEqual(false, drv.data_toggle[1]);
     try testing.expectEqual(false, drv.data_toggle[2]);
     try testing.expectEqual(false, drv.data_toggle[3]);


### PR DESCRIPTION
## Description

SET_CONFIGURATION 処理時にエンドポイント1-3の data_toggle を明示的に DATA0 にリセットするよう修正。

USB 2.0 仕様では SET_CONFIGURATION 後のエンドポイントの data toggle は DATA0 から開始すべきだが、現状の実装では `handleBusReset` でのみリセットしており、再設定（re-configuration）時には正しくリセットされない可能性があった。

### 変更内容

- `hwConfigureEndpoints` 呼び出し前に EP1-EP3 の `data_toggle` を `false` (DATA0) にリセット
- SET_CONFIGURATION 後の data_toggle リセットを検証するテストを2件追加
  - 初回設定時のリセット確認
  - 再設定時のリセット確認

## Types of Changes

- [x] Bugfix

## Issues Fixed or Closed by This PR

* Closes #242

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).