### PR TITLE
feat: GET_CONFIGURATION / GET_PROTOCOL レスポンスを実装

### DIFF
--- a/src/hal/usb.zig
+++ b/src/hal/usb.zig
@@ -198,6 +198,7 @@ pub const UsbDriver = struct {
         self.ep0_in_offset = 0;
         self.ep0_in_total_len = 0;
         self.pending_address = null;
+        self.ep0_reply_buf = .{0};
         self.mock_ep0_out_data = 0;
         self.mock_ints = 0;
         self.mock_setup_packet = null;


### PR DESCRIPTION
## Description

USB コントロール転送の GET_CONFIGURATION および GET_PROTOCOL リクエストに対して、実際のレスポンスデータを EP0 IN に送信するよう実装しました。

- **GET_CONFIGURATION** (bmRequestType=0x80, bRequest=8): 現在の `configuration` 値（1バイト）を返す。未設定なら 0、設定済みなら bConfigurationValue（通常 1）。`wLength` に応じたクランプ処理付き
- **GET_PROTOCOL** (bmRequestType=0xA1, bRequest=3): `wIndex` で指定されたインターフェースの現在のプロトコル値（0=Boot, 1=Report）を1バイトで返す。未知のインターフェースには STALL で応答。`wLength` に応じたクランプ処理付き
- データ保持用の `ep0_reply_buf` フィールドを `UsbDriver` に追加し、`sendEp0InPacket()` を使用して送信

## Types of Changes

- [x] Core
- [x] New feature

## Issues Fixed or Closed by This PR

* Closes #241

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).