### PR TITLE
fix: CDC送信のbusy-waitがメインループをブロックする問題を修正

### DIFF
--- a/src/hal/usb.zig
+++ b/src/hal/usb.zig
@@ -509,6 +509,13 @@ pub const UsbDriver = struct {
         }
 
         if (is_freestanding) {
+            // Check if previous packet is still pending (AVAILABLE=1).
+            // If so, skip this flush to avoid blocking the main loop.
+            const buf_ctrl_addr = USBCTRL_DPRAM_BASE + DPRAM.EP_BUF_CTRL_BASE +
+                @as(u32, usb_descriptors.CDC_DATA_ENDPOINT) * 8;
+            const buf_ctrl = @as(*volatile u32, @ptrFromInt(buf_ctrl_addr));
+            if (buf_ctrl.* & BufCtrl.AVAILABLE != 0) return;
+
             self.hwSendCdcData(packet[0..send_len]);
         } else {
             // Mock: just advance data_toggle
@@ -850,8 +857,7 @@ pub const UsbDriver = struct {
         const buf_ctrl_addr = USBCTRL_DPRAM_BASE + DPRAM.EP_BUF_CTRL_BASE + @as(u32, ep) * 8;
         const buf_ctrl = @as(*volatile u32, @ptrFromInt(buf_ctrl_addr));
 
-        // Wait for previous packet to be consumed
-        while (buf_ctrl.* & BufCtrl.AVAILABLE != 0) {}
+        // Caller (cdcFlush) guarantees AVAILABLE=0 before calling this function.
 
         const buf = @as([*]volatile u8, @ptrFromInt(USBCTRL_DPRAM_BASE + DPRAM.EP5_IN_BUF));
         const len = @min(data.len, 64);


### PR DESCRIPTION
## Description

`cdcFlush()` が `task()` から毎イテレーション呼ばれるが、`hwSendCdcData()` 内の busy-wait（EP5 IN BUF_CTRL の AVAILABLE ビット待ち）がメインループをブロックする問題を修正。

`cdcFlush()` で `hwSendCdcData()` を呼ぶ前に AVAILABLE ビットをチェックし、前パケットが未送信（AVAILABLE=1）なら早期リターンするように変更した。これにより:

- ホスト側 CDC バッファがフルの場合でもマトリックススキャンが停止しない
- 送信できなかったデータはリングバッファに残り、次回の `cdcFlush()` で再試行される
- `hwSendCdcData()` 内の busy-wait ループも、呼び出し元で保証済みのため削除

## Types of Changes

- [x] Bugfix

## Issues Fixed or Closed by This PR

* Closes #257

## Checklist

- [x] My code follows the code style of this project.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).