### PR TITLE
fix: UF2アドレスオフセットのバグ修正と診断ログ追加

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -63,13 +63,9 @@ pub fn build(b: *std.Build) void {
     elf_size_step.dependOn(&install_firmware.step);
     b.getInstallStep().dependOn(elf_size_step);
 
-    // Optional boot2 binary path (required for booting on real hardware)
-    // Obtain from pico-sdk: boot_stage2/boot2_w25q080.bin (or appropriate variant)
-    const boot2_path = b.option([]const u8, "boot2", "Path to boot2.bin (256-byte second stage bootloader from pico-sdk)");
-
     // UF2 conversion step
     const uf2_step = b.step("uf2", "Convert firmware to UF2 format");
-    const uf2_install = addUf2Step(b, firmware, native_target, keyboard, keymap, boot2_path);
+    const uf2_install = addUf2Step(b, firmware, native_target, keyboard, keymap);
     uf2_step.dependOn(&uf2_install.step);
 
     // UF2 ファイルサイズ表示
@@ -149,7 +145,6 @@ fn addUf2Step(
     native_target: std.Build.ResolvedTarget,
     keyboard: []const u8,
     keymap: []const u8,
-    boot2_path: ?[]const u8,
 ) *std.Build.Step.InstallFile {
     const raw_bin = firmware.addObjCopy(.{
         .format = .bin,
@@ -166,9 +161,6 @@ fn addUf2Step(
     const uf2_run = b.addRunArtifact(uf2_gen);
     uf2_run.addFileArg(raw_bin.getOutput());
     const uf2_output = uf2_run.addOutputFileArg(b.fmt("{s}_{s}.uf2", .{ keyboard, keymap }));
-    if (boot2_path) |path| {
-        uf2_run.addArg(path);
-    }
 
     return b.addInstallFile(uf2_output, b.fmt("{s}_{s}.uf2", .{ keyboard, keymap }));
 }

--- a/src/hal/cdc_console.zig
+++ b/src/hal/cdc_console.zig
@@ -23,7 +23,7 @@ pub fn init(drv: *usb_mod.UsbDriver) void {
 /// Write raw data to CDC
 pub fn write(data: []const u8) void {
     if (usb_driver) |drv| {
-        if (drv.isConfigured() and drv.cdcDtrActive()) {
+        if (drv.isConfigured()) {
             drv.cdcWrite(data);
         }
     }
@@ -32,7 +32,7 @@ pub fn write(data: []const u8) void {
 /// Formatted print to CDC
 pub fn print(comptime fmt: []const u8, args: anytype) void {
     if (usb_driver) |drv| {
-        if (drv.isConfigured() and drv.cdcDtrActive()) {
+        if (drv.isConfigured()) {
             drv.cdcPrint(fmt, args);
         }
     }

--- a/src/hal/usb.zig
+++ b/src/hal/usb.zig
@@ -862,8 +862,8 @@ pub const UsbDriver = struct {
         const buf_ctrl_addr = USBCTRL_DPRAM_BASE + DPRAM.EP_BUF_CTRL_BASE + @as(u32, ep) * 8;
         const buf_ctrl = @as(*volatile u32, @ptrFromInt(buf_ctrl_addr));
 
-        // Wait for previous packet to be consumed by host before overwriting
-        while (buf_ctrl.* & BufCtrl.AVAILABLE != 0) {}
+        // Skip if previous packet is still pending (non-blocking)
+        if (buf_ctrl.* & BufCtrl.AVAILABLE != 0) return;
 
         // Calculate buffer address in DPRAM (must match hwConfigureEndpoints)
         const buf_addr = USBCTRL_DPRAM_BASE + DPRAM.EP_BUF_BASE + (@as(u32, ep) - 1) * 64;

--- a/src/main.zig
+++ b/src/main.zig
@@ -83,6 +83,7 @@ pub const startup = if (is_freestanding) struct {
 
     const gpio = @import("hal/gpio.zig");
     const usb = @import("hal/usb.zig");
+    const timer = @import("hal/timer.zig");
     const cdc_console = @import("hal/cdc_console.zig");
     const eeprom_mod = @import("hal/eeprom.zig");
     const matrix_mod = @import("core/matrix.zig");
@@ -118,6 +119,11 @@ pub const startup = if (is_freestanding) struct {
         keyboard.getTestKeymap().* = kb_mod.default_keymap;
         action_mod.setActionResolver(keyboard.keymapActionResolver);
 
+        // 診断用変数
+        var loop_count: u32 = 0;
+        var last_heartbeat: u32 = timer.read32();
+        var prev_matrix: [kb_mod.rows]u32 = .{0} ** kb_mod.rows;
+
         // メインループ
         while (true) {
             // USBイベントポーリング（SETUP_REQ/BUS_RESET/BUFF_STATUS処理）
@@ -131,6 +137,27 @@ pub const startup = if (is_freestanding) struct {
 
             // キーボードタスク実行（差分検出 → イベント生成 → アクション実行）
             keyboard.task();
+
+            // 診断ログ
+            loop_count +%= 1;
+
+            // マトリックス変化検出ログ
+            for (0..kb_mod.rows) |row| {
+                const current = matrix.getRow(@intCast(row));
+                if (current != prev_matrix[row]) {
+                    cdc_console.print("matrix[{d}]: 0x{X:0>4} -> 0x{X:0>4}\r\n", .{ row, prev_matrix[row], current });
+                    prev_matrix[row] = current;
+                }
+            }
+
+            // 定期ハートビートログ（5秒ごと）
+            const now = timer.read32();
+            if (timer.elapsed32(last_heartbeat) >= 5000) {
+                const usb_state: []const u8 = if (usb_driver.isConfigured()) "configured" else "not configured";
+                cdc_console.print("[heartbeat] loops={d} usb={s}\r\n", .{ loop_count, usb_state });
+                last_heartbeat = now;
+                loop_count = 0;
+            }
         }
     }
 } else struct {};

--- a/tools/uf2gen.zig
+++ b/tools/uf2gen.zig
@@ -6,13 +6,10 @@
 //! See: https://github.com/microsoft/uf2
 //!
 //! Usage:
-//!   uf2gen <input.bin> <output.uf2> [boot2.bin]
+//!   uf2gen <input.bin> <output.uf2>
 //!
-//! If boot2.bin is provided (256 bytes, CRC32-padded), it will be placed at
-//! flash address 0x10000000. Firmware is placed at 0x10000100.
-//! If boot2.bin is omitted, firmware starts at 0x10000100 without boot2.
-//!
-//! Boot2 binaries can be obtained from pico-sdk (boot_stage2/).
+//! The raw binary includes boot2 (256 bytes at offset 0) followed by firmware.
+//! The entire binary is placed at flash address 0x10000000.
 
 const std = @import("std");
 
@@ -22,10 +19,8 @@ const UF2_MAGIC_END: u32 = 0x0AB16F30;
 const UF2_FLAG_FAMILY_ID: u32 = 0x00002000;
 const RP2040_FAMILY_ID: u32 = 0xe48bff56;
 const FLASH_BASE: u32 = 0x10000000;
-const FIRMWARE_BASE: u32 = 0x10000100; // Application starts after 256-byte boot2
 const PAYLOAD_SIZE: u32 = 256;
 const BLOCK_SIZE: u32 = 512;
-const BOOT2_SIZE: u32 = 256;
 
 const UF2Block = extern struct {
     magic_start0: u32 = UF2_MAGIC_START0,
@@ -50,72 +45,33 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(std.heap.page_allocator);
     defer std.process.argsFree(std.heap.page_allocator, args);
 
-    if (args.len < 3 or args.len > 4) {
-        std.debug.print("Usage: uf2gen <input.bin> <output.uf2> [boot2.bin]\n", .{});
-        std.debug.print("\n", .{});
-        std.debug.print("  boot2.bin  Optional: 256-byte boot2 binary (from pico-sdk boot_stage2/)\n", .{});
-        std.debug.print("             Required for firmware to boot on real RP2040 hardware.\n", .{});
+    if (args.len != 3) {
+        std.debug.print("Usage: uf2gen <input.bin> <output.uf2>\n", .{});
         return error.InvalidArgs;
     }
 
     const input_path = args[1];
     const output_path = args[2];
-    const boot2_path: ?[]const u8 = if (args.len == 4) args[3] else null;
 
-    // Read firmware binary
+    // Read raw binary (boot2 at offset 0 + firmware at offset 0x100)
     const input_file = try std.fs.cwd().openFile(input_path, .{});
     defer input_file.close();
     const firmware_data = try input_file.readToEndAlloc(std.heap.page_allocator, 2 * 1024 * 1024);
     defer std.heap.page_allocator.free(firmware_data);
 
-    // Read boot2 binary (optional)
-    var boot2_data: ?[]u8 = null;
-    defer if (boot2_data) |d| std.heap.page_allocator.free(d);
-    if (boot2_path) |path| {
-        const boot2_file = try std.fs.cwd().openFile(path, .{});
-        defer boot2_file.close();
-        const data = try boot2_file.readToEndAlloc(std.heap.page_allocator, BOOT2_SIZE + 1);
-        if (data.len != BOOT2_SIZE) {
-            std.debug.print("Error: boot2.bin must be exactly {d} bytes (got {d})\n", .{ BOOT2_SIZE, data.len });
-            return error.InvalidBoot2Size;
-        }
-        boot2_data = data;
-    } else {
-        std.debug.print(
-            "Warning: no boot2.bin provided. Firmware will not boot on real hardware.\n" ++
-                "         Use `zig build uf2 -Dboot2=<path>` to include boot2.\n",
-            .{},
-        );
-    }
-
     // Calculate total block count
-    const firmware_blocks: u32 = @intCast((firmware_data.len + PAYLOAD_SIZE - 1) / PAYLOAD_SIZE);
-    const boot2_blocks: u32 = if (boot2_data != null) 1 else 0;
-    const num_blocks: u32 = boot2_blocks + firmware_blocks;
+    const num_blocks: u32 = @intCast((firmware_data.len + PAYLOAD_SIZE - 1) / PAYLOAD_SIZE);
 
     const output_file = try std.fs.cwd().createFile(output_path, .{});
     defer output_file.close();
 
-    var block_no: u32 = 0;
-
-    // Write boot2 block at 0x10000000
-    if (boot2_data) |b2| {
-        var block = UF2Block{
-            .target_addr = FLASH_BASE,
-            .block_no = block_no,
-            .num_blocks = num_blocks,
-        };
-        @memcpy(block.data[0..BOOT2_SIZE], b2);
-        try output_file.writeAll(std.mem.asBytes(&block));
-        block_no += 1;
-    }
-
-    // Write firmware blocks starting at 0x10000100
+    // Write all blocks starting at FLASH_BASE (0x10000000)
+    // Raw binary layout: boot2 (0x00-0xFF) + firmware (0x100+)
     var i: u32 = 0;
-    while (i < firmware_blocks) : (i += 1) {
+    while (i < num_blocks) : (i += 1) {
         var block = UF2Block{
-            .target_addr = FIRMWARE_BASE + i * PAYLOAD_SIZE,
-            .block_no = block_no,
+            .target_addr = FLASH_BASE + i * PAYLOAD_SIZE,
+            .block_no = i,
             .num_blocks = num_blocks,
         };
 
@@ -124,14 +80,12 @@ pub fn main() !void {
         @memcpy(block.data[0 .. end - start], firmware_data[start..end]);
 
         try output_file.writeAll(std.mem.asBytes(&block));
-        block_no += 1;
     }
 
-    std.debug.print("Created {s}: {d} blocks ({d} firmware + {d} boot2), {d} bytes firmware\n", .{
+    std.debug.print("Created {s}: {d} blocks, {d} bytes (boot2+firmware at 0x{X:0>8})\n", .{
         output_path,
         num_blocks,
-        firmware_blocks,
-        boot2_blocks,
         firmware_data.len,
+        FLASH_BASE,
     });
 }


### PR DESCRIPTION
## Description

UF2生成時のアドレスオフセットに起因するboot2配置のバグを修正し、デバッグ用の診断ログを追加した。

### 修正内容

- **UF2アドレスオフセット修正**: UF2生成時のアドレスが `FIRMWARE_BASE(0x10000100)` から配置されていたため、boot2（先頭256バイト）がずれていた問題を修正。ELFのphysical addressをそのまま使用するように変更
- **boot2.bin オプション削除**: boot2はELFに含まれているため、外部から`boot2.bin`を指定するビルドオプションを削除
- **hwSendEndpoint busy-wait修正**: `hwSendEndpoint`のbusy-waitをearly returnに変更し、メインループをブロックしないようにした
- **CDC DTRチェック緩和**: CDC consoleのDTRチェックを緩和し、接続性を改善
- **診断ログ追加**: メインループにハートビートログとマトリックス変化ログを追加し、実機デバッグを容易にした

## Types of Changes

- [x] Bugfix

## Issues Fixed or Closed by This PR

* Closes #161

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).