### PR TITLE
chore: flash_run の依存関係整理 (#368)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -75,7 +75,6 @@ pub fn build(b: *std.Build) void {
     uf2_step.dependOn(uf2_size_step);
 
     // Flash step: build UF2 and copy to RP2040 BOOTSEL drive
-    // flash_run が uf2_size_step に依存することで、 UF2 サイズ表示 → flash 開始 の順序を保証する。
     const flash_step = b.step("flash", "Flash firmware to RP2040 via BOOTSEL mode");
     const flash_run = addFlashStep(b, uf2_install, uf2_size_step, native_target, keyboard, keymap);
     flash_step.dependOn(&flash_run.step);

--- a/build.zig
+++ b/build.zig
@@ -75,10 +75,10 @@ pub fn build(b: *std.Build) void {
     uf2_step.dependOn(uf2_size_step);
 
     // Flash step: build UF2 and copy to RP2040 BOOTSEL drive
+    // flash_run が uf2_size_step に依存することで、 UF2 サイズ表示 → flash 開始 の順序を保証する。
     const flash_step = b.step("flash", "Flash firmware to RP2040 via BOOTSEL mode");
-    const flash_run = addFlashStep(b, uf2_install, native_target, keyboard, keymap);
+    const flash_run = addFlashStep(b, uf2_install, uf2_size_step, native_target, keyboard, keymap);
     flash_step.dependOn(&flash_run.step);
-    flash_step.dependOn(uf2_size_step);
 
     // Test module
     const test_mod = b.createModule(.{
@@ -120,6 +120,7 @@ pub fn build(b: *std.Build) void {
 fn addFlashStep(
     b: *std.Build,
     uf2_install: *std.Build.Step.InstallFile,
+    uf2_size_step: *std.Build.Step,
     native_target: std.Build.ResolvedTarget,
     keyboard: []const u8,
     keymap: []const u8,
@@ -135,6 +136,8 @@ fn addFlashStep(
     const flash_run = b.addRunArtifact(flash_tool);
     flash_run.addArg(b.getInstallPath(.prefix, b.fmt("{s}_{s}.uf2", .{ keyboard, keymap })));
     flash_run.step.dependOn(&uf2_install.step);
+    // UF2 サイズ表示 → flash 実行 の順序を保証 (出力混在防止)
+    flash_run.step.dependOn(uf2_size_step);
 
     return flash_run;
 }


### PR DESCRIPTION
## Description

issue #368 [Q5] への対応。 `.claude/skills/build-flash-improvements.md` の Q5 セクションに従って、 build.zig の flash 関連 step の依存を整理。

### 変更内容

- `addFlashStep` 関数シグネチャに `uf2_size_step: *std.Build.Step` を追加
- 関数内で `flash_run.step.dependOn(uf2_size_step)` を追加 (UF2 サイズ表示 → flash 実行 の順序保証)
- 呼び出し側の `flash_step.dependOn(uf2_size_step)` (重複指定) を削除
- これで `zig build flash` の出力順が `UF2 サイズ表示 → flash 開始` で安定し、 サイズ表示と flash ログの混在が防止される

### 影響

機能的な変更はなく、 `zig build flash` の挙動はサイズ表示の順序保証以外に変化なし。 `zig build` (default install) や `zig build uf2` の挙動も不変。

## Types of Changes

- [x] Enhancement/optimization (出力順序の安定化)

## Issues Fixed or Closed by This PR

* Closes #368

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage). (build.zig の依存追加のみで挙動変化は順序保証のみ、 CI で `zig build verify` 緑を確認)