### PR TITLE
refactor: integration_test.zig の is_madbd5 残置を解消

### DIFF
--- a/src/keyboards/madbd34.zig
+++ b/src/keyboards/madbd34.zig
@@ -13,6 +13,7 @@
 const keycode = @import("core").keycode;
 const keymap = @import("core").keymap;
 const matrix = @import("core").matrix;
+const event = @import("core").event;
 const gpio = @import("hal").gpio;
 const Keycode = keycode.Keycode;
 const KC = keycode.KC;
@@ -164,34 +165,35 @@ fn buildKeymap() keymap.Keymap {
 /// `src/tests/integration_test.zig` から参照されるキー位置情報。
 /// キーボード固有のレイアウト差を吸収し、 統合テストをキーボード非依存に保つ。
 /// 新規キーボード追加時はこの構造体を同等に定義することで integration_test.zig の編集が不要になる。
+///
+/// 型は `core.event.KeyPos` を使用 (フィールド順は col, row)。
+/// 既存の KeyEvent.key と同じ型を流用することで二重定義を避ける。
 pub const test_positions = struct {
-    pub const Pos = struct { row: u8, col: u8 };
-
     /// Layer 0 の基本キー位置
-    pub const q_pos = Pos{ .row = 0, .col = 1 };
-    pub const w_pos = Pos{ .row = 0, .col = 2 };
-    pub const e_pos = Pos{ .row = 0, .col = 3 };
-    pub const tab_pos = Pos{ .row = 0, .col = 0 };
-    pub const lctl_pos = Pos{ .row = 1, .col = 0 };
-    pub const a_pos = Pos{ .row = 1, .col = 1 };
-    pub const lsft_pos = Pos{ .row = 2, .col = 0 };
-    pub const z_pos = Pos{ .row = 2, .col = 1 };
+    pub const q_pos = event.KeyPos{ .col = 1, .row = 0 };
+    pub const w_pos = event.KeyPos{ .col = 2, .row = 0 };
+    pub const e_pos = event.KeyPos{ .col = 3, .row = 0 };
+    pub const tab_pos = event.KeyPos{ .col = 0, .row = 0 };
+    pub const lctl_pos = event.KeyPos{ .col = 0, .row = 1 };
+    pub const a_pos = event.KeyPos{ .col = 1, .row = 1 };
+    pub const lsft_pos = event.KeyPos{ .col = 0, .row = 2 };
+    pub const z_pos = event.KeyPos{ .col = 1, .row = 2 };
 
     /// Layer-Tap / MO キー位置 (thumb cluster)
-    pub const lt1_spc_pos = Pos{ .row = 3, .col = 5 };
-    pub const lt2_esc_pos = Pos{ .row = 3, .col = 6 };
-    pub const mo1_pos = Pos{ .row = 3, .col = 8 };
+    pub const lt1_spc_pos = event.KeyPos{ .col = 5, .row = 3 };
+    pub const lt2_esc_pos = event.KeyPos{ .col = 6, .row = 3 };
+    pub const mo1_pos = event.KeyPos{ .col = 8, .row = 3 };
 
     /// Layer 2 ナビゲーションキー (LEFT)
-    pub const l2_left_pos = Pos{ .row = 1, .col = 6 };
+    pub const l2_left_pos = event.KeyPos{ .col = 6, .row = 1 };
 
     /// Layer 3 ファンクションキー (F1 開始列、 row 0 の F1〜F12 が連続して並ぶ)
     pub const l3_f1_col: u8 = 0;
 
     /// Layer 3 メディアキー
-    pub const l3_mute_pos = Pos{ .row = 1, .col = 1 };
-    pub const l3_vold_pos = Pos{ .row = 1, .col = 2 };
-    pub const l3_volu_pos = Pos{ .row = 1, .col = 3 };
+    pub const l3_mute_pos = event.KeyPos{ .col = 1, .row = 1 };
+    pub const l3_vold_pos = event.KeyPos{ .col = 2, .row = 1 };
+    pub const l3_volu_pos = event.KeyPos{ .col = 3, .row = 1 };
 };
 
 // ============================================================

--- a/src/keyboards/madbd34.zig
+++ b/src/keyboards/madbd34.zig
@@ -158,6 +158,43 @@ fn buildKeymap() keymap.Keymap {
 }
 
 // ============================================================
+// 統合テスト用キー位置定数
+// ============================================================
+
+/// `src/tests/integration_test.zig` から参照されるキー位置情報。
+/// キーボード固有のレイアウト差を吸収し、 統合テストをキーボード非依存に保つ。
+/// 新規キーボード追加時はこの構造体を同等に定義することで integration_test.zig の編集が不要になる。
+pub const test_positions = struct {
+    pub const Pos = struct { row: u8, col: u8 };
+
+    /// Layer 0 の基本キー位置
+    pub const q_pos = Pos{ .row = 0, .col = 1 };
+    pub const w_pos = Pos{ .row = 0, .col = 2 };
+    pub const e_pos = Pos{ .row = 0, .col = 3 };
+    pub const tab_pos = Pos{ .row = 0, .col = 0 };
+    pub const lctl_pos = Pos{ .row = 1, .col = 0 };
+    pub const a_pos = Pos{ .row = 1, .col = 1 };
+    pub const lsft_pos = Pos{ .row = 2, .col = 0 };
+    pub const z_pos = Pos{ .row = 2, .col = 1 };
+
+    /// Layer-Tap / MO キー位置 (thumb cluster)
+    pub const lt1_spc_pos = Pos{ .row = 3, .col = 5 };
+    pub const lt2_esc_pos = Pos{ .row = 3, .col = 6 };
+    pub const mo1_pos = Pos{ .row = 3, .col = 8 };
+
+    /// Layer 2 ナビゲーションキー (LEFT)
+    pub const l2_left_pos = Pos{ .row = 1, .col = 6 };
+
+    /// Layer 3 ファンクションキー (F1 開始列、 row 0 の F1〜F12 が連続して並ぶ)
+    pub const l3_f1_col: u8 = 0;
+
+    /// Layer 3 メディアキー
+    pub const l3_mute_pos = Pos{ .row = 1, .col = 1 };
+    pub const l3_vold_pos = Pos{ .row = 1, .col = 2 };
+    pub const l3_volu_pos = Pos{ .row = 1, .col = 3 };
+};
+
+// ============================================================
 // テスト
 // ============================================================
 

--- a/src/keyboards/madbd34.zig
+++ b/src/keyboards/madbd34.zig
@@ -114,6 +114,11 @@ pub fn LAYOUT(comptime keys: [key_count]Keycode) [rows][cols]Keycode {
 /// この値は実際に使用するレイヤー数のメタデータとして使用する。
 pub const num_layers: u8 = 4;
 
+// 物理レイアウト視認性のため zig fmt を無効化。
+// LAYOUT() のキー配列は手動整形により行/列構造（左手 / 右手 / thumb）が
+// 視覚的に対応しており、 zig fmt の均等カラム整形では境界が崩れる。
+// zig fmt: off
+
 /// Layer 0: QWERTY ベースレイヤー
 const layer0 = LAYOUT(.{
     KC.TAB,  KC.Q,  KC.W,  KC.E,  KC.R,  KC.T,               KC.Y,  KC.U,  KC.I,    KC.O,    KC.P,    KC.BSPC,
@@ -145,6 +150,7 @@ const layer3 = LAYOUT(.{
     KC.NO, KC.NO,   KC.NO,   KC.NO,   KC.NO, KC.NO,           KC.MS_WH_LEFT, KC.MS_WH_DOWN, KC.MS_WH_UP, KC.MS_WH_RIGHT, KC.NO,
                   KC.LCTL, KC.LGUI, keycode.LT(2, KC.SPC),  keycode.LT(1, KC.ESC), KC.RALT, KC.NO,
 });
+// zig fmt: on
 
 /// デフォルトキーマップ（4レイヤー分）
 pub const default_keymap: keymap.Keymap = buildKeymap();

--- a/src/keyboards/madbd5.zig
+++ b/src/keyboards/madbd5.zig
@@ -13,6 +13,7 @@
 const keycode = @import("core").keycode;
 const keymap = @import("core").keymap;
 const matrix = @import("core").matrix;
+const event = @import("core").event;
 const gpio = @import("hal").gpio;
 const Keycode = keycode.Keycode;
 const KC = keycode.KC;
@@ -209,34 +210,35 @@ fn buildKeymap() keymap.Keymap {
 /// `src/tests/integration_test.zig` から参照されるキー位置情報。
 /// キーボード固有のレイアウト差を吸収し、 統合テストをキーボード非依存に保つ。
 /// 新規キーボード追加時はこの構造体を同等に定義することで integration_test.zig の編集が不要になる。
+///
+/// 型は `core.event.KeyPos` を使用 (フィールド順は col, row)。
+/// 既存の KeyEvent.key と同じ型を流用することで二重定義を避ける。
 pub const test_positions = struct {
-    pub const Pos = struct { row: u8, col: u8 };
-
     /// Layer 0 の基本キー位置
-    pub const q_pos = Pos{ .row = 0, .col = 5 };
-    pub const w_pos = Pos{ .row = 0, .col = 6 };
-    pub const e_pos = Pos{ .row = 0, .col = 7 };
-    pub const tab_pos = Pos{ .row = 0, .col = 4 };
-    pub const lctl_pos = Pos{ .row = 1, .col = 4 };
-    pub const a_pos = Pos{ .row = 1, .col = 5 };
-    pub const lsft_pos = Pos{ .row = 2, .col = 4 };
-    pub const z_pos = Pos{ .row = 2, .col = 5 };
+    pub const q_pos = event.KeyPos{ .col = 5, .row = 0 };
+    pub const w_pos = event.KeyPos{ .col = 6, .row = 0 };
+    pub const e_pos = event.KeyPos{ .col = 7, .row = 0 };
+    pub const tab_pos = event.KeyPos{ .col = 4, .row = 0 };
+    pub const lctl_pos = event.KeyPos{ .col = 4, .row = 1 };
+    pub const a_pos = event.KeyPos{ .col = 5, .row = 1 };
+    pub const lsft_pos = event.KeyPos{ .col = 4, .row = 2 };
+    pub const z_pos = event.KeyPos{ .col = 5, .row = 2 };
 
     /// Layer-Tap / MO キー位置 (thumb cluster)
-    pub const lt1_spc_pos = Pos{ .row = 3, .col = 6 };
-    pub const lt2_esc_pos = Pos{ .row = 3, .col = 7 };
-    pub const mo1_pos = Pos{ .row = 3, .col = 9 };
+    pub const lt1_spc_pos = event.KeyPos{ .col = 6, .row = 3 };
+    pub const lt2_esc_pos = event.KeyPos{ .col = 7, .row = 3 };
+    pub const mo1_pos = event.KeyPos{ .col = 9, .row = 3 };
 
     /// Layer 2 ナビゲーションキー (LEFT)
-    pub const l2_left_pos = Pos{ .row = 1, .col = 10 };
+    pub const l2_left_pos = event.KeyPos{ .col = 10, .row = 1 };
 
     /// Layer 3 ファンクションキー (F1 開始列、 row 0 の F1〜F12 が連続して並ぶ)
     pub const l3_f1_col: u8 = 4;
 
     /// Layer 3 メディアキー
-    pub const l3_mute_pos = Pos{ .row = 1, .col = 5 };
-    pub const l3_vold_pos = Pos{ .row = 1, .col = 6 };
-    pub const l3_volu_pos = Pos{ .row = 1, .col = 7 };
+    pub const l3_mute_pos = event.KeyPos{ .col = 5, .row = 1 };
+    pub const l3_vold_pos = event.KeyPos{ .col = 6, .row = 1 };
+    pub const l3_volu_pos = event.KeyPos{ .col = 7, .row = 1 };
 };
 
 // ============================================================

--- a/src/keyboards/madbd5.zig
+++ b/src/keyboards/madbd5.zig
@@ -120,6 +120,11 @@ pub fn LAYOUT(comptime keys: [key_count]Keycode) [rows][cols]Keycode {
 // デフォルトキーマップ
 // ============================================================
 
+// 物理レイアウト視認性のため zig fmt を無効化。
+// LAYOUT() のキー配列は手動整形により行/列構造（numpad / left / right / thumb）が
+// 視覚的に対応しており、 zig fmt の均等カラム整形では境界が崩れる。
+// zig fmt: off
+
 /// Layer 0: QWERTY ベースレイヤー（テンキー付き）
 const layer0 = LAYOUT(.{
     // Row 0: numpad + QWERTY上段
@@ -187,6 +192,7 @@ const layer6 = LAYOUT(.{
     KC.F1,   KC.F2,   KC.F3,         KC.F4,                                                   KC.LCTL, KC.LGUI, KC.SPC, KC.ESC, KC.RALT, KC.NO,
     KC.KP_0,          KC.LEFT_SHIFT, KC.RIGHT_SHIFT,
 });
+// zig fmt: on
 
 /// デフォルトキーマップ（7レイヤー分）
 pub const default_keymap: keymap.Keymap = buildKeymap();

--- a/src/keyboards/madbd5.zig
+++ b/src/keyboards/madbd5.zig
@@ -203,6 +203,43 @@ fn buildKeymap() keymap.Keymap {
 }
 
 // ============================================================
+// 統合テスト用キー位置定数
+// ============================================================
+
+/// `src/tests/integration_test.zig` から参照されるキー位置情報。
+/// キーボード固有のレイアウト差を吸収し、 統合テストをキーボード非依存に保つ。
+/// 新規キーボード追加時はこの構造体を同等に定義することで integration_test.zig の編集が不要になる。
+pub const test_positions = struct {
+    pub const Pos = struct { row: u8, col: u8 };
+
+    /// Layer 0 の基本キー位置
+    pub const q_pos = Pos{ .row = 0, .col = 5 };
+    pub const w_pos = Pos{ .row = 0, .col = 6 };
+    pub const e_pos = Pos{ .row = 0, .col = 7 };
+    pub const tab_pos = Pos{ .row = 0, .col = 4 };
+    pub const lctl_pos = Pos{ .row = 1, .col = 4 };
+    pub const a_pos = Pos{ .row = 1, .col = 5 };
+    pub const lsft_pos = Pos{ .row = 2, .col = 4 };
+    pub const z_pos = Pos{ .row = 2, .col = 5 };
+
+    /// Layer-Tap / MO キー位置 (thumb cluster)
+    pub const lt1_spc_pos = Pos{ .row = 3, .col = 6 };
+    pub const lt2_esc_pos = Pos{ .row = 3, .col = 7 };
+    pub const mo1_pos = Pos{ .row = 3, .col = 9 };
+
+    /// Layer 2 ナビゲーションキー (LEFT)
+    pub const l2_left_pos = Pos{ .row = 1, .col = 10 };
+
+    /// Layer 3 ファンクションキー (F1 開始列、 row 0 の F1〜F12 が連続して並ぶ)
+    pub const l3_f1_col: u8 = 4;
+
+    /// Layer 3 メディアキー
+    pub const l3_mute_pos = Pos{ .row = 1, .col = 5 };
+    pub const l3_vold_pos = Pos{ .row = 1, .col = 6 };
+    pub const l3_volu_pos = Pos{ .row = 1, .col = 7 };
+};
+
+// ============================================================
 // テスト
 // ============================================================
 

--- a/src/tests/integration_test.zig
+++ b/src/tests/integration_test.zig
@@ -19,7 +19,6 @@
 
 const std = @import("std");
 const testing = std.testing;
-const build_options = @import("build_options");
 
 // Core modules
 const action = @import("core").action_mod;
@@ -49,39 +48,40 @@ const Keycode = keycode.Keycode;
 const IntegrationMockDriver = @import("core").test_driver.FixedTestDriver(64, 16);
 
 // ============================================================
-// キーボード固有のキーポジション定数
+// キーボード固有のキー位置定数
 // ============================================================
+//
+// 各キーボード定義 (`src/keyboards/<name>.zig`) の `pub const test_positions`
+// から参照する。 これにより integration_test.zig 自体はキーボード非依存となり、
+// 新規キーボード追加時に test_positions を該当 keyboard 定義に追加するだけで
+// このファイルの編集は不要になる。
+// 関連: Issue #359 / #383
 
-const Pos = struct { row: u8, col: u8 };
+/// Layer 0 の基本キー位置
+const Q_POS = kb.test_positions.q_pos;
+const W_POS = kb.test_positions.w_pos;
+const E_POS = kb.test_positions.e_pos;
+const TAB_POS = kb.test_positions.tab_pos;
+const LCTL_POS = kb.test_positions.lctl_pos;
+const A_POS = kb.test_positions.a_pos;
+const LSFT_POS = kb.test_positions.lsft_pos;
+const Z_POS = kb.test_positions.z_pos;
 
-/// キーボード固有のキーポジションを comptime で定義
-const is_madbd5 = std.mem.eql(u8, build_options.KEYBOARD, "madbd5");
-
-/// Layer 0 の基本キーポジション
-const Q_POS = if (is_madbd5) Pos{ .row = 0, .col = 5 } else Pos{ .row = 0, .col = 1 };
-const W_POS = if (is_madbd5) Pos{ .row = 0, .col = 6 } else Pos{ .row = 0, .col = 2 };
-const E_POS = if (is_madbd5) Pos{ .row = 0, .col = 7 } else Pos{ .row = 0, .col = 3 };
-const TAB_POS = if (is_madbd5) Pos{ .row = 0, .col = 4 } else Pos{ .row = 0, .col = 0 };
-const LCTL_POS = if (is_madbd5) Pos{ .row = 1, .col = 4 } else Pos{ .row = 1, .col = 0 };
-const A_POS = if (is_madbd5) Pos{ .row = 1, .col = 5 } else Pos{ .row = 1, .col = 1 };
-const LSFT_POS = if (is_madbd5) Pos{ .row = 2, .col = 4 } else Pos{ .row = 2, .col = 0 };
-const Z_POS = if (is_madbd5) Pos{ .row = 2, .col = 5 } else Pos{ .row = 2, .col = 1 };
-
-/// Layer-Tap / MO キーポジション
-const LT1_SPC_POS = if (is_madbd5) Pos{ .row = 3, .col = 6 } else Pos{ .row = 3, .col = 5 };
-const LT2_ESC_POS = if (is_madbd5) Pos{ .row = 3, .col = 7 } else Pos{ .row = 3, .col = 6 };
-const MO1_POS = if (is_madbd5) Pos{ .row = 3, .col = 9 } else Pos{ .row = 3, .col = 8 };
+/// Layer-Tap / MO キー位置
+const LT1_SPC_POS = kb.test_positions.lt1_spc_pos;
+const LT2_ESC_POS = kb.test_positions.lt2_esc_pos;
+const MO1_POS = kb.test_positions.mo1_pos;
 
 /// Layer 2 ナビゲーションキー
-const L2_LEFT_POS = if (is_madbd5) Pos{ .row = 1, .col = 10 } else Pos{ .row = 1, .col = 6 };
+const L2_LEFT_POS = kb.test_positions.l2_left_pos;
 
-/// Layer 3 ファンクションキー
-const L3_F1_COL: u8 = if (is_madbd5) 4 else 0;
+/// Layer 3 ファンクションキー (F1 開始列)
+const L3_F1_COL: u8 = kb.test_positions.l3_f1_col;
 
 /// Layer 3 メディアキー
-const L3_MUTE_POS = if (is_madbd5) Pos{ .row = 1, .col = 5 } else Pos{ .row = 1, .col = 1 };
-const L3_VOLD_POS = if (is_madbd5) Pos{ .row = 1, .col = 6 } else Pos{ .row = 1, .col = 2 };
-const L3_VOLU_POS = if (is_madbd5) Pos{ .row = 1, .col = 7 } else Pos{ .row = 1, .col = 3 };
+const L3_MUTE_POS = kb.test_positions.l3_mute_pos;
+const L3_VOLD_POS = kb.test_positions.l3_vold_pos;
+const L3_VOLU_POS = kb.test_positions.l3_volu_pos;
 
 // ============================================================
 // kb キーマップからアクションを解決するリゾルバ


### PR DESCRIPTION
## Description

`src/tests/integration_test.zig` に残置されていた `is_madbd5 = std.mem.eql(u8, build_options.KEYBOARD, "madbd5")` ベースの 16 個の if-else 定数を、 `kb.test_positions` 経由のキーボード固有定数定義に置換。 Issue #359 (PR #382) で完成した `@import("active_keyboard")` パターンを tests に拡張。

## 背景

PR #382 (Issue #359) で `if (mem.eql(...)) @import(...)` 連鎖は `@import("active_keyboard")` 経由に置換済み。 ただし `src/tests/integration_test.zig` の `is_madbd5` ベース定数 16 個が残置されており、 新規キーボード追加時にこのファイル編集が必要な状態だった。

## 採用方針

issue 案 A: 各キーボード定義 (`src/keyboards/<name>.zig`) に `pub const test_positions = struct { ... }` を追加し、 `integration_test.zig` は `kb.test_positions.<name>` 経由で参照。

## コミット粒度

1. `refactor: integration_test.zig の is_madbd5 残置を解消 (#383)` — 案 A 実装本体
2. `refactor: test_positions の Pos 型を core.event.KeyPos に統一 (#383)` — devils-advocate 指摘対応 (DRY 違反解消、 既存 `core.event.KeyPos` 再利用)

## レビュー記録 (ローカル多角レビュー)

### コードレビュー判定: APPROVE

- 値完全一致 (16 定数すべて旧コードと一致、 手で全件突き合わせ済み)
- `is_madbd5` / `build_options` の痕跡完全消去
- comptime safety: 新規 keyboard で `test_positions` 未実装なら **コンパイルエラー** (旧コードの「`is_madbd5 = false` で確定し全定数が madbd34 値で誤って解決される」サイレント・バグが構造的に不可能に)
- madbd5: **1110 / 1110** pass、 madbd34: **1109 / 1109** pass
- production binary 影響ゼロ (`.text + .rodata: 443.7 KB` で test_positions あり/なし完全一致、 Zig dead code elimination 実証)

### devils-advocate 指摘

- ✅ **本 PR で対応**: `Pos` 型重複定義 → `core.event.KeyPos` に統一 (2 コミット目)
- ⏭️ **別 issue 化候補** (本 PR スコープ越え、 マージ後に起票予定):
  - 案 C (TestFixture ベース化、 integration_test を keyboard 非依存に)
  - `test_positions` schema の明示化 (implicit interface → documented contract)
  - 関心混在 (test 用定数を `keyboards/` から `tests/key_positions/` に分離検討)
  - 16 定数の最大公約数問題 (キーボード固有キーのテスト拡張性)
  - QWERTY 論理位置 vs アクション位置 (LT1_SPC など) の意味的混在

## ローカルテスト結果

| コマンド | 結果 |
|---|---|
| `zig build test -Dkeyboard=madbd5` | ✅ 1110 / 1110 pass |
| `zig build test -Dkeyboard=madbd34` | ✅ 1109 / 1109 pass |
| `zig build verify` | ✅ pass |
| `zig build -Dkeyboard=madbd34` | ✅ UF2 生成成功 |
| `zig fmt --check` (新規変更部分) | ✅ pass |

`zig fmt --check` はリポジトリ全体では既存の LAYOUT 整列の差分が残っているが、 これは PR スコープ外 (master 時点から存在)。 本 PR の新規追加部分には fmt 違反なし。

## Acceptance Criteria 達成状況

- [x] `src/tests/integration_test.zig` から `is_madbd5` の判定削除
- [x] 新規 keyboard 追加時に `integration_test.zig` 編集不要 (`<name>.zig` 新設のみで完結)
- [x] 既存 madbd5 / madbd34 の全テスト緑

## Types of Changes

- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Closes #383

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **PR Checklist** document and have made the appropriate changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes (構造改善 PR、 既存テスト群が変更を validate)
- [x] I have tested the changes and verified that they work and don't break anything