### PR TITLE
refactor: ABI export を keymap_lookup 経由化して二重路線解消

### DIFF
--- a/src/compat/qmk_abi.zig
+++ b/src/compat/qmk_abi.zig
@@ -15,7 +15,6 @@ const action_mod = @import("core").action_mod;
 const keyboard_mod = @import("core").keyboard;
 const event_mod = @import("core").event;
 const keymap_mod = @import("core").keymap;
-const keymap_state = @import("core").keymap_state;
 const report_mod = @import("core").report;
 const timer = @import("hal").timer;
 
@@ -252,11 +251,13 @@ export fn advance_time(ms: u32) void {
 // ============================================================
 
 /// Get keycode at given layer and position
-/// keymap_state が保持する現在の keymap を参照する
+/// 依存性注入された keymap lookup (`keyboard.keymapLookup`) 経由で参照する。
+/// production binary では `productionKeymapLookup` 経由で `keymap_state` を引き、
+/// test binary では `test_fixture` の lookup を経由するため、 ABI から
+/// production/test storage を直接触ることはない (DRY 統一)。
 export fn keymap_key_to_keycode(layer: u8, row: u8, col: u8) u16 {
-    const km = keymap_state.getKeymap();
     if (layer >= keymap_mod.MAX_LAYERS) return 0;
-    return keymap_mod.keymapKeyToKeycode(km, @intCast(layer), row, col);
+    return keyboard_mod.keymapLookup(@intCast(layer), row, col);
 }
 
 // ============================================================
@@ -405,24 +406,31 @@ test "qmk_abi: process_record does not crash" {
     process_record(0, 0, false, 200);
 }
 
-test "qmk_abi: keymap_key_to_keycode returns keycode from test keymap" {
+test "qmk_abi: keymap_key_to_keycode returns keycode from injected lookup" {
     const keycode_mod = @import("core").keycode;
     const km_mod = @import("core").keymap;
+
+    // ABI export `keymap_key_to_keycode` は注入済み lookup (`keyboard.keymapLookup`)
+    // 経由でキーマップを参照する。 test 用に専用 storage と lookup を注入し、
+    // ABI 経由のルックアップ経路を検証する。
+    const TestKeymapStorage = struct {
+        var km: km_mod.Keymap = km_mod.emptyKeymap();
+        fn lookup(l: u5, row: u8, col: u8) keycode_mod.Keycode {
+            return km_mod.keymapKeyToKeycode(&km, l, row, col);
+        }
+    };
+
     keyboard_init();
-    // ABI export `keymap_key_to_keycode` は production storage (`keymap_state`) を参照する。
-    // test 専用 storage (test_fixture.test_keymap) とは別物のため、 ここでは
-    // `keymap_state` を直接書き換えて ABI 経由のルックアップを検証する。
-    keymap_state.getKeymap().* = km_mod.emptyKeymap();
+    TestKeymapStorage.km = km_mod.emptyKeymap();
+    keyboard_mod.setKeymapLookup(TestKeymapStorage.lookup);
+    defer keyboard_mod.clearKeymapLookup();
+
     try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(0, 0, 0));
 
-    // production storage にキーを設定
-    keymap_state.getKeymap()[0][0][0] = keycode_mod.KC.A;
+    // 注入された storage にキーを設定
+    TestKeymapStorage.km[0][0][0] = keycode_mod.KC.A;
     try testing.expectEqual(keycode_mod.KC.A, keymap_key_to_keycode(0, 0, 0));
 
     // 範囲外のレイヤーは 0 を返す
     try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(255, 0, 0));
-
-    // クリーンアップ
-    keymap_state.getKeymap().* = km_mod.emptyKeymap();
-    keyboard_init();
 }

--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -75,6 +75,14 @@ pub fn clearKeymapLookup() void {
     keymap_lookup = defaultKeymapLookup;
 }
 
+/// 注入済みキーマップ参照関数を呼び出すラッパー。
+/// production / test それぞれの storage に依存せず、 注入された lookup
+/// を経由してキーコードを取得するための統一エントリポイント。
+/// C ABI export (`compat/qmk_abi.zig`) からも参照される。
+pub fn keymapLookup(l: u5, row: u8, col: u8) Keycode {
+    return keymap_lookup(l, row, col);
+}
+
 /// マトリックス状態: 各行のビットマスク（テスト時は外部から設定可能）
 var matrix_state: [MATRIX_ROWS]u32 = .{0} ** MATRIX_ROWS;
 var matrix_prev: [MATRIX_ROWS]u32 = .{0} ** MATRIX_ROWS;


### PR DESCRIPTION
## Description

`src/compat/qmk_abi.zig` の `keymap_key_to_keycode` ABI 関数を `keyboard.keymapLookup` 経由に統一し、 PR #398 で残った「ABI と production パイプラインで keymap データへのアクセス経路が二重」 という DRY 違反 / 整合性破綻リスクを解消。

## 背景

PR #398 (Issue #395) で `core/keyboard.zig` から `keymap_state` 依存を依存性注入で排除したが、 `qmk_abi.zig` の `keymap_key_to_keycode` は依然として `keymap_state.getKeymap()` を直接参照していた (PR #398 のローカル devils-advocate 指摘)。

## 採用設計

1. **`keyboard.zig` に `pub fn keymapLookup(l, row, col)` 公開関数を追加** (private な `keymap_lookup` 関数ポインタを呼ぶ薄いラッパー)
2. **`qmk_abi.zig` の `keymap_key_to_keycode` を `keyboard_mod.keymapLookup` 経由に変更**
3. **`qmk_abi.zig` から `keymap_state` import を削除** (痕跡完全消去)
4. **ABI signature 維持** (`keymap_key_to_keycode(layer, row, col)` の C ABI 互換性保持、 issue 例の `*KeyPos` 化は別 issue 検討)
5. **qmk_abi.zig 内 test を専用 storage + 独自 lookup 注入に書き換え** (test_fixture と同パターン)

### keymap_state.zig の扱い

本 PR では維持。 ABI が lookup 経由になり keymap_state の役割は production startup と productionKeymapLookup のみとなったが、 完全削除は **Issue #400 で別途扱う**。 「1 PR 1 課題」 の原則。

## レビュー記録 (ローカル多角レビュー)

### コードレビュー判定: APPROVE

- `grep -n "keymap_state" src/compat/qmk_abi.zig` → コメント本文 1 件のみ、 実コード参照は **完全ゼロ**
- ELF サイズ完全一致 (master と branch 両方で madbd5 / madbd34 確認済み)
- 内部 hot path (`resolveKeycode` / `keymapActionResolver`) は引き続き `keymap_lookup` を直接呼び、 LLVM が `keymapLookup` を inline 展開するため production binary に追加コードゼロ
- 既存 test_fixture / keyboard.zig 内 test と同一パターン (`TestKeymapStorage` struct + `var km` + `fn lookup`) で整合
- `defer keyboard_mod.clearKeymapLookup()` で teardown 保証

### devils-advocate 指摘

- 軽微 (本 PR では対応せず別 issue 化候補):
  - `keymapLookup` ラッパーが PR #398 で削除した `lookupKey` と矛盾して見える → docstring 補強で意図明示
  - ABI signature 案 (`*KeyPos` 版) を採用しなかった理由を PR 説明に明記 (本 PR で記載済み)
  - keymap_state.zig コメント更新 → Issue #400 でまとめる

これらはマージ後に必要に応じて別 issue 起票検討。

## ローカルテスト結果

| コマンド | 結果 |
|---|---|
| `zig build test -Dkeyboard=madbd5` | ✅ **1105 / 1105** pass |
| `zig build test -Dkeyboard=madbd34` | ✅ **1104 / 1104** pass |
| `zig build verify` | ✅ 全緑 |
| `zig fmt --check src tools build.zig` | ✅ pass |

## ELF サイズ検証

| 項目 | master | branch | 差分 |
|---|---:|---:|---:|
| madbd5 ELF | 2089796 bytes | 2089796 bytes | 0 |
| madbd5 .text+.rodata | 441.0 KB | 441.0 KB | 0 |
| madbd5 .bin | 462828 bytes | 462828 bytes | 0 |
| madbd34 ELF | 2022360 bytes | 2022360 bytes | 0 |
| madbd34 .text+.rodata | 438.1 KB | 438.1 KB | 0 |

production binary 完全一致 (LLVM dead code elimination + inline 展開で実コスト 0)。

## Acceptance Criteria 達成状況

- [x] `qmk_abi.zig` の `keymap_key_to_keycode` が `keymap_lookup` 経由
- [x] `keymap_state` 直接参照を ABI から削除 (grep 0 件)
- [x] 既存テスト緑 (madbd5 1105, madbd34 1104)
- [x] production binary サイズ維持 (両 keyboard で完全一致)

## Types of Changes

- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Closes #399

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **PR Checklist** document
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes (test 書き換えで lookup 注入パターンに統一)
- [x] I have tested the changes and verified that they work and don't break anything