### PR TITLE
refactor: keymap_key_to_keycode の signature を (layer, KeyPos) 値渡しに変更

### DIFF
--- a/src/compat/qmk_abi.zig
+++ b/src/compat/qmk_abi.zig
@@ -279,7 +279,6 @@ export fn advance_time(ms: u32) void {
 /// は `(row: u8, col: u8, ...)` 平置き signature。 `keymap_key_to_keycode`
 /// だけ `KeyPos` 値渡しに変更したため、 ABI 内 signature 不統一。
 /// 将来 ABI 全体を `KeyPos` ベースに統一する場合は別 issue で検討する。
-/// 本 PR では `keymap_key_to_keycode` のみ対応。
 ///
 /// 注意: `KeyPos` は `packed struct { col: u8, row: u8 }` で `@sizeOf == 2`。
 /// C 側から呼ぶ場合は `keypos_t` (col, row 順) のレイアウトが必要。

--- a/src/compat/qmk_abi.zig
+++ b/src/compat/qmk_abi.zig
@@ -256,26 +256,36 @@ export fn advance_time(ms: u32) void {
 /// (flash 上の静的 const) を引き、 test binary では `test_fixture.test_keymap` (BSS)
 /// を引くため、 ABI からそれぞれの実体を直接触ることはない (DRY 統一)。
 ///
-/// ## Signature: `(layer: u8, key_pos_ptr: *const KeyPos) u16` (Issue #406)
+/// ## Signature: `(layer: u8, key_pos: KeyPos) u16` (Issue #406)
 ///
 /// 元 issue #399 で提案された型安全な signature を採用 (Issue #406)。
 /// 内部 `KeymapLookupFn` は `(layer, row, col)` のままだが、 ABI export だけは
-/// `KeyPos` 構造体ポインタを受け取る形に変更。
+/// `KeyPos` 構造体を受け取る形に変更。
 /// 利点:
 /// - 型安全 (KeyPos 構造体で row/col をまとめて引数順序ミスを防止)
 /// - 将来の拡張性 (KeyPos に追加情報を持たせる余地)
 /// - upstream C 版 QMK の `keymap_key_to_keycode(uint8_t layer, keypos_t key)`
-///   と概念的に一致 (upstream は値渡し、 Zig 版はポインタ渡しでアラインメント
-///   非依存)
+///   と完全一致 (値渡し)
+/// - Cortex-M0+ AAPCS では 2 byte packed struct は r0 レジスタ 1 本に収まり、
+///   ポインタ渡しより効率的
+/// - アラインメント問題は packed struct (`@sizeOf == 2`) の設計上発生しない
 ///
 /// 内部 lookup signature を維持する理由は `core/keyboard.zig` の
 /// `KeymapLookupFn` docstring 参照 (Issue #403 で確定)。
 ///
+/// ## ABI 全体の signature 統一 (将来検討)
+///
+/// 現状、 本ファイル内の他の export 関数 (`action_exec`, `process_record`)
+/// は `(row: u8, col: u8, ...)` 平置き signature。 `keymap_key_to_keycode`
+/// だけ `KeyPos` 値渡しに変更したため、 ABI 内 signature 不統一。
+/// 将来 ABI 全体を `KeyPos` ベースに統一する場合は別 issue で検討する。
+/// 本 PR では `keymap_key_to_keycode` のみ対応。
+///
 /// 注意: `KeyPos` は `packed struct { col: u8, row: u8 }` で `@sizeOf == 2`。
 /// C 側から呼ぶ場合は `keypos_t` (col, row 順) のレイアウトが必要。
-export fn keymap_key_to_keycode(layer: u8, key_pos_ptr: *const event_mod.KeyPos) u16 {
+export fn keymap_key_to_keycode(layer: u8, key_pos: event_mod.KeyPos) u16 {
     if (layer >= keymap_mod.MAX_LAYERS) return 0;
-    return keyboard_mod.keymapLookup(@intCast(layer), key_pos_ptr.row, key_pos_ptr.col);
+    return keyboard_mod.keymapLookup(@intCast(layer), key_pos.row, key_pos.col);
 }
 
 // ============================================================
@@ -443,18 +453,16 @@ test "qmk_abi: keymap_key_to_keycode returns keycode from injected lookup" {
     keyboard_mod.setKeymapLookup(TestKeymapStorage.lookup);
     defer keyboard_mod.clearKeymapLookup();
 
-    var pos = event_mod.KeyPos{ .col = 0, .row = 0 };
-    try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(0, &pos));
+    try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(0, event_mod.KeyPos{ .col = 0, .row = 0 }));
 
     // 注入された storage にキーを設定
     TestKeymapStorage.km[0][0][0] = keycode_mod.KC.A;
-    try testing.expectEqual(keycode_mod.KC.A, keymap_key_to_keycode(0, &pos));
+    try testing.expectEqual(keycode_mod.KC.A, keymap_key_to_keycode(0, event_mod.KeyPos{ .col = 0, .row = 0 }));
 
     // 範囲外のレイヤーは 0 を返す
-    try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(255, &pos));
+    try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(255, event_mod.KeyPos{ .col = 0, .row = 0 }));
 
     // 別の (row, col) を別キーコードで検証 (KeyPos 経由のフィールドアクセス確認)
     TestKeymapStorage.km[0][2][3] = keycode_mod.KC.B;
-    var pos2 = event_mod.KeyPos{ .col = 3, .row = 2 };
-    try testing.expectEqual(keycode_mod.KC.B, keymap_key_to_keycode(0, &pos2));
+    try testing.expectEqual(keycode_mod.KC.B, keymap_key_to_keycode(0, event_mod.KeyPos{ .col = 3, .row = 2 }));
 }

--- a/src/compat/qmk_abi.zig
+++ b/src/compat/qmk_abi.zig
@@ -250,14 +250,32 @@ export fn advance_time(ms: u32) void {
 // Keymap
 // ============================================================
 
-/// Get keycode at given layer and position
+/// Get keycode at given layer and position (C ABI export)
 /// 依存性注入された keymap lookup (`keyboard.keymapLookup`) 経由で参照する。
 /// production binary では `productionKeymapLookup` 経由で `kb_mod.default_keymap`
 /// (flash 上の静的 const) を引き、 test binary では `test_fixture.test_keymap` (BSS)
 /// を引くため、 ABI からそれぞれの実体を直接触ることはない (DRY 統一)。
-export fn keymap_key_to_keycode(layer: u8, row: u8, col: u8) u16 {
+///
+/// ## Signature: `(layer: u8, key_pos_ptr: *const KeyPos) u16` (Issue #406)
+///
+/// 元 issue #399 で提案された型安全な signature を採用 (Issue #406)。
+/// 内部 `KeymapLookupFn` は `(layer, row, col)` のままだが、 ABI export だけは
+/// `KeyPos` 構造体ポインタを受け取る形に変更。
+/// 利点:
+/// - 型安全 (KeyPos 構造体で row/col をまとめて引数順序ミスを防止)
+/// - 将来の拡張性 (KeyPos に追加情報を持たせる余地)
+/// - upstream C 版 QMK の `keymap_key_to_keycode(uint8_t layer, keypos_t key)`
+///   と概念的に一致 (upstream は値渡し、 Zig 版はポインタ渡しでアラインメント
+///   非依存)
+///
+/// 内部 lookup signature を維持する理由は `core/keyboard.zig` の
+/// `KeymapLookupFn` docstring 参照 (Issue #403 で確定)。
+///
+/// 注意: `KeyPos` は `packed struct { col: u8, row: u8 }` で `@sizeOf == 2`。
+/// C 側から呼ぶ場合は `keypos_t` (col, row 順) のレイアウトが必要。
+export fn keymap_key_to_keycode(layer: u8, key_pos_ptr: *const event_mod.KeyPos) u16 {
     if (layer >= keymap_mod.MAX_LAYERS) return 0;
-    return keyboard_mod.keymapLookup(@intCast(layer), row, col);
+    return keyboard_mod.keymapLookup(@intCast(layer), key_pos_ptr.row, key_pos_ptr.col);
 }
 
 // ============================================================
@@ -425,12 +443,18 @@ test "qmk_abi: keymap_key_to_keycode returns keycode from injected lookup" {
     keyboard_mod.setKeymapLookup(TestKeymapStorage.lookup);
     defer keyboard_mod.clearKeymapLookup();
 
-    try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(0, 0, 0));
+    var pos = event_mod.KeyPos{ .col = 0, .row = 0 };
+    try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(0, &pos));
 
     // 注入された storage にキーを設定
     TestKeymapStorage.km[0][0][0] = keycode_mod.KC.A;
-    try testing.expectEqual(keycode_mod.KC.A, keymap_key_to_keycode(0, 0, 0));
+    try testing.expectEqual(keycode_mod.KC.A, keymap_key_to_keycode(0, &pos));
 
     // 範囲外のレイヤーは 0 を返す
-    try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(255, 0, 0));
+    try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(255, &pos));
+
+    // 別の (row, col) を別キーコードで検証 (KeyPos 経由のフィールドアクセス確認)
+    TestKeymapStorage.km[0][2][3] = keycode_mod.KC.B;
+    var pos2 = event_mod.KeyPos{ .col = 3, .row = 2 };
+    try testing.expectEqual(keycode_mod.KC.B, keymap_key_to_keycode(0, &pos2));
 }

--- a/src/core/event.zig
+++ b/src/core/event.zig
@@ -8,7 +8,12 @@
 //! Based on quantum/keyboard.h
 
 /// Key position in the matrix
-pub const KeyPos = packed struct {
+///
+/// `packed struct(u16)` で backing integer を明示することで、
+/// `export fn` の値引数として使用可能 (Issue #406)。
+/// signedness が unsigned に確定するため、 C ABI の calling convention 上
+/// 安定した受け渡しが行える。
+pub const KeyPos = packed struct(u16) {
     col: u8,
     row: u8,
 };

--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -71,14 +71,6 @@ pub const MATRIX_COLS = keymap_mod.MATRIX_COLS;
 /// `compat/qmk_abi.zig` の `keymap_key_to_keycode` は型安全性のため
 /// `(layer, KeyPos)` (値渡し) を採用 (Issue #406 で決定)。
 /// ABI 側で KeyPos からフィールドを展開して内部 lookup に渡す薄い wrapper を持つ。
-///
-/// ## ABI 全体の signature 統一 (将来検討)
-///
-/// 現状、 `qmk_abi.zig` の他の export 関数 (`action_exec`, `process_record`)
-/// は `(row: u8, col: u8, ...)` 平置き signature。 `keymap_key_to_keycode`
-/// だけ `KeyPos` 値渡しに変更したため、 ABI 内 signature 不統一。
-/// 将来 ABI 全体を `KeyPos` ベースに統一する場合は別 issue で検討する。
-/// 本 PR では `keymap_key_to_keycode` のみ対応。
 pub const KeymapLookupFn = *const fn (l: u5, row: u8, col: u8) Keycode;
 
 /// 未設定時のデフォルト lookup。 常に `KC.NO` を返す。

--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -69,8 +69,16 @@ pub const MATRIX_COLS = keymap_mod.MATRIX_COLS;
 ///
 /// 内部 `KeymapLookupFn` は `(layer, row, col)` のままだが、 ABI export
 /// `compat/qmk_abi.zig` の `keymap_key_to_keycode` は型安全性のため
-/// `(layer, *const KeyPos)` を採用 (Issue #406 で決定)。
+/// `(layer, KeyPos)` (値渡し) を採用 (Issue #406 で決定)。
 /// ABI 側で KeyPos からフィールドを展開して内部 lookup に渡す薄い wrapper を持つ。
+///
+/// ## ABI 全体の signature 統一 (将来検討)
+///
+/// 現状、 `qmk_abi.zig` の他の export 関数 (`action_exec`, `process_record`)
+/// は `(row: u8, col: u8, ...)` 平置き signature。 `keymap_key_to_keycode`
+/// だけ `KeyPos` 値渡しに変更したため、 ABI 内 signature 不統一。
+/// 将来 ABI 全体を `KeyPos` ベースに統一する場合は別 issue で検討する。
+/// 本 PR では `keymap_key_to_keycode` のみ対応。
 pub const KeymapLookupFn = *const fn (l: u5, row: u8, col: u8) Keycode;
 
 /// 未設定時のデフォルト lookup。 常に `KC.NO` を返す。

--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -55,18 +55,22 @@ pub const MATRIX_COLS = keymap_mod.MATRIX_COLS;
 /// 案として「lookup 内部でレイヤー解決まで行う signature」 (`fn(layer_state, row, col) -> Keycode`)
 /// が検討されたが、以下の理由で採用しなかった:
 ///
-/// 1. **C ABI 互換性** — C 版 QMK の `keymap_key_to_keycode(uint8_t layer, ...)` は
-///    単一レイヤー引きの signature。 ABI export (`compat/qmk_abi.zig` の
-///    `keymap_key_to_keycode`) を Zig core と DRY に共有するには signature 一致が必須。
-/// 2. **責務分離** — レイヤー解決は core パイプラインの責務 (`resolveKeycode` /
+/// 1. **責務分離** — レイヤー解決は core パイプラインの責務 (`resolveKeycode` /
 ///    `keymapActionResolver`) であり、 source layer cache の更新 (キー押下時に
 ///    レイヤーを記憶し、 リリース時に同じレイヤーを参照する仕組み) と密結合する。
 ///    cache 更新は副作用であり、 「純粋な lookup 関数」 と相容れない。
-/// 3. **DRY** — レイヤー解決を lookup に移すと production / test の両方で同じ
+/// 2. **DRY** — レイヤー解決を lookup に移すと production / test の両方で同じ
 ///    16 layer ループ + 透過判定を書く必要があり重複が発生する。 現状は
 ///    `layer.layerSwitchGetLayer` の一箇所のみで重複なし。
-/// 4. **lookup の責務最小化** — 「keymap storage を引くだけ」 の純粋関数は最も
+/// 3. **lookup の責務最小化** — 「keymap storage を引くだけ」 の純粋関数は最も
 ///    シンプルかつテストしやすい形であり、 production binary でもインライン化が容易。
+///
+/// ## 内部 signature と ABI export signature の差異 (Issue #406)
+///
+/// 内部 `KeymapLookupFn` は `(layer, row, col)` のままだが、 ABI export
+/// `compat/qmk_abi.zig` の `keymap_key_to_keycode` は型安全性のため
+/// `(layer, *const KeyPos)` を採用 (Issue #406 で決定)。
+/// ABI 側で KeyPos からフィールドを展開して内部 lookup に渡す薄い wrapper を持つ。
 pub const KeymapLookupFn = *const fn (l: u5, row: u8, col: u8) Keycode;
 
 /// 未設定時のデフォルト lookup。 常に `KC.NO` を返す。

--- a/src/core/layer.zig
+++ b/src/core/layer.zig
@@ -240,8 +240,11 @@ fn readSourceLayersCacheImpl(entry_number: u16, cache: *const [cacheStorageSize(
 /// Checks layers from highest to lowest, combining layer_state and default_layer_state.
 /// keymapFn: fn(layer: u5, row: u8, col: u8) Keycode
 ///
-/// 注: lookup 関数は単一レイヤー引きの signature (C 版 `keymap_key_to_keycode`
-/// 相当) を要求する。 レイヤー状態は本関数内で `layer_state | default_layer_state`
+/// 注: lookup 関数は単一レイヤー引きの signature を要求する
+/// (Issue #403 で確定。 内部 `KeymapLookupFn` の signature。
+/// ABI export `keymap_key_to_keycode` は別の signature `(layer, KeyPos)` で
+/// Issue #406 で変更済み)。
+/// レイヤー状態は本関数内で `layer_state | default_layer_state`
 /// として参照し、 透過判定込みでアクティブレイヤーを決定する。
 pub fn layerSwitchGetLayer(keymapFn: anytype, row: u8, col: u8) u5 {
     const layers = layer_state | default_layer_state;


### PR DESCRIPTION
## Description

PR #404 (Issue #399) で「ABI signature 維持」 を採用した `keymap_key_to_keycode` を、 値渡し `KeyPos` 構造体 signature に変更。 Issue #399 本文の元提案 (`*KeyPos`) を **値渡し** で実装し、 upstream C 版 `keypos_t key` と完全一致。

## 採用設計 (案 A 改良版: 値渡し化)

### Signature: `(layer: u8, key_pos: KeyPos) u16`

```zig
export fn keymap_key_to_keycode(layer: u8, key_pos: event.KeyPos) u16 {
    if (layer >= keymap.MAX_LAYERS) return 0;
    return keyboard.keymapLookup(@intCast(layer), key_pos.row, key_pos.col);
}
```

### 採用理由

- **型安全**: `KeyPos` 構造体で row/col をまとめて引数順序ミスを防止
- **upstream C 版完全一致**: `keymap_key_to_keycode(uint8_t layer, keypos_t key)` (値渡し)
- **Cortex-M0+ AAPCS で効率的**: 2 byte packed struct は r0 レジスタ 1 本に収まる
- **アラインメント問題なし**: packed struct (`@sizeOf == 2`) の設計上発生しない
- **将来の拡張性**: KeyPos に追加情報を持たせる余地

### 経緯
1. **PR #404 (Issue #399)**: ABI signature 維持を選択
2. 本 PR で「C 側呼び出し 0 件確認 → 互換維持の論拠なし」 を再評価し変更
3. 当初 `*const KeyPos` (ポインタ渡し) で実装したが、 ローカル devils-advocate の指摘 (「2 byte なら値渡しが Cortex-M0+ で効率的、 upstream とも一致」) を受け **値渡し** に変更

## 副次変更: KeyPos の `packed struct(u16)` 明示化

Zig 0.16.0 では `export fn` の値引数として packed struct を使うには backing integer の signedness 確定が必須 (コンパイル要件)。 `KeyPos` を `packed struct(u16)` に明示化:

- 既存 `@bitCast(KeyPos) → u16` セマンティクス維持 (`abi_test.zig` の "ABI: KeyPos bit layout matches C keypos_t" と整合)
- 最小影響 (`extern struct` 化や値渡し諦めは不採用)

## コミット粒度

1. `04230f0d refactor: keymap_key_to_keycode の signature を (layer, *KeyPos) に変更 (#406)` — 初期実装 (ポインタ渡し)
2. `a7972e9e refactor: keymap_key_to_keycode を値渡しに変更 (upstream C 版互換)` — devils-advocate 指摘対応
3. `c0234e3d chore: layer.zig コメントを ABI signature 変更後の状態に追従` — reviewer 指摘対応

## レビュー記録 (ローカル多角レビュー)

### コードレビュー判定: APPROVE
- C 側呼び出し 0 件 (`grep -rn "keymap_key_to_keycode" quantum`) を独自検証
- 新 signature の妥当性 (型安全 + upstream 互換)
- KeyPos リテラル直渡しでテスト書き換え正確
- ELF 197132 bytes 完全一致

### devils-advocate 指摘 (チーム協議結果)

- ✅ **本 PR で対応**:
  - **値渡し化** (3.1: ポインタ渡しの妥当性) — `*const KeyPos` → `KeyPos` に変更
  - **layer.zig:243 コメント整合** (reviewer 推奨)
  - **docstring に「ABI 全体統一は将来検討」 明記** (devils-advocate 2.1)

- ⏭️ **別 issue 化候補** (本 PR スコープ越え):
  - **ABI 全体統一** (`action_exec` / `process_record` も `KeyPos` 化、 ABI 内 signature 不統一解消)
  - 内部 `KeymapLookupFn` 統一 (Issue #403 で Won't Do 確定済み、 再検討しない)

## ローカルテスト結果

| コマンド | 結果 |
|---|---|
| `zig build test -Dkeyboard=madbd5` | ✅ **1117 / 1117** pass |
| `zig build test -Dkeyboard=madbd34` | ✅ **1116 / 1116** pass |
| `zig build verify` | ✅ 全緑 |
| `zig fmt --check src tools build.zig` | ✅ pass |

## ELF サイズ検証

| 項目 | master | branch | 差分 |
|---|---:|---:|---:|
| ELF total | **197132 bytes** | **197132 bytes** | **0** |
| .text+.rodata | 24.3 KB | 24.3 KB | 0 |
| .data | 1.7 KB | 1.7 KB | 0 |
| .bss | 0.6 KB | 0.6 KB | 0 |

production binary 完全一致 (LLVM dead code elimination + inline 展開)。

## Acceptance Criteria 達成状況

- [x] `keymap_key_to_keycode` の signature を新 signature に変更 (値渡し採用)
- [x] 既存テスト緑 (madbd5 1117, madbd34 1116)
- [x] production binary サイズ維持 (197132 bytes)

## Types of Changes

- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Closes #406

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **PR Checklist** document
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly (KeymapLookupFn / qmk_abi.zig / layer.zig docstring 更新)
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes (新 signature テスト書き換え + 追加 1 件)
- [x] I have tested the changes and verified that they work and don't break anything