### PR TITLE
refactor: defaultKeymapLookup を panic 化してサイレントバグ排除

### DIFF
--- a/src/compat/qmk_abi.zig
+++ b/src/compat/qmk_abi.zig
@@ -422,13 +422,38 @@ test "qmk_abi: host_set_driver/host_get_driver null" {
 }
 
 test "qmk_abi: action_exec does not crash" {
+    // keymap_lookup / action_resolver の前テストからのリークを排除し、
+    // 「ABI 経由で action_exec を呼んでもクラッシュしない」 を純粋に検証する。
+    // Issue #401: defaultKeymapLookup が panic 化されたため、 keymap_lookup を
+    // 呼びうるパスを通すテストは明示的に lookup を注入する必要がある。
+    const keycode_mod = @import("core").keycode;
+    const TestStorage = struct {
+        fn lookup(_: u5, _: u8, _: u8) keycode_mod.Keycode {
+            return keycode_mod.KC.NO;
+        }
+    };
+    keyboard_mod.setKeymapLookup(TestStorage.lookup);
+    defer keyboard_mod.clearKeymapLookup();
+    action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
     keyboard_init();
+
     action_exec(0, 0, true, 100);
     action_exec(0, 0, false, 200);
 }
 
 test "qmk_abi: process_record does not crash" {
+    // Issue #401: action_exec does not crash と同様の理由で lookup / resolver を注入。
+    const keycode_mod = @import("core").keycode;
+    const TestStorage = struct {
+        fn lookup(_: u5, _: u8, _: u8) keycode_mod.Keycode {
+            return keycode_mod.KC.NO;
+        }
+    };
+    keyboard_mod.setKeymapLookup(TestStorage.lookup);
+    defer keyboard_mod.clearKeymapLookup();
+    action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
     keyboard_init();
+
     process_record(0, 0, true, 100);
     process_record(0, 0, false, 200);
 }

--- a/src/compat/qmk_abi.zig
+++ b/src/compat/qmk_abi.zig
@@ -421,21 +421,29 @@ test "qmk_abi: host_set_driver/host_get_driver null" {
     try testing.expectEqual(@as(?*const CHostDriver, null), host_get_driver());
 }
 
+/// Issue #401 のテスト用 file-scope な lookup スタブ。
+/// 「ABI 経由で action_exec / process_record を呼んでもクラッシュしない」 を
+/// 検証するため、 panic しない最小の lookup として常に `KC.NO` を返す。
+///
+/// anonymous struct (test 内 inline 定義) ではなく file-scope に出した理由:
+/// 関数ポインタ取得を test 関数本体の comptime コンテキスト外で完結させ、
+/// test 順序を入れ替えても挙動が変わらないことを構造的に保証する。
+fn testNoCrashLookup(_: u5, _: u8, _: u8) @import("core").keycode.Keycode {
+    return @import("core").keycode.KC.NO;
+}
+
 test "qmk_abi: action_exec does not crash" {
-    // keymap_lookup / action_resolver の前テストからのリークを排除し、
     // 「ABI 経由で action_exec を呼んでもクラッシュしない」 を純粋に検証する。
     // Issue #401: defaultKeymapLookup が panic 化されたため、 keymap_lookup を
-    // 呼びうるパスを通すテストは明示的に lookup を注入する必要がある。
-    const keycode_mod = @import("core").keycode;
-    const TestStorage = struct {
-        fn lookup(_: u5, _: u8, _: u8) keycode_mod.Keycode {
-            return keycode_mod.KC.NO;
-        }
-    };
-    keyboard_mod.setKeymapLookup(TestStorage.lookup);
+    // 呼びうるパスを通すテストは明示的に lookup と action_resolver を注入する。
+    //
+    // 呼び出し順序契約: keyboard_init() は内部で keymap_lookup と action_resolver を
+    // リセットするため、 必ず init の **後に** setKeymapLookup / setActionResolver
+    // を呼ぶこと。
+    keyboard_init();
+    keyboard_mod.setKeymapLookup(testNoCrashLookup);
     defer keyboard_mod.clearKeymapLookup();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
-    keyboard_init();
 
     action_exec(0, 0, true, 100);
     action_exec(0, 0, false, 200);
@@ -443,16 +451,10 @@ test "qmk_abi: action_exec does not crash" {
 
 test "qmk_abi: process_record does not crash" {
     // Issue #401: action_exec does not crash と同様の理由で lookup / resolver を注入。
-    const keycode_mod = @import("core").keycode;
-    const TestStorage = struct {
-        fn lookup(_: u5, _: u8, _: u8) keycode_mod.Keycode {
-            return keycode_mod.KC.NO;
-        }
-    };
-    keyboard_mod.setKeymapLookup(TestStorage.lookup);
+    keyboard_init();
+    keyboard_mod.setKeymapLookup(testNoCrashLookup);
     defer keyboard_mod.clearKeymapLookup();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
-    keyboard_init();
 
     process_record(0, 0, true, 100);
     process_record(0, 0, false, 200);

--- a/src/core/action.zig
+++ b/src/core/action.zig
@@ -760,6 +760,11 @@ pub fn reset() void {
     keymap_mod.keymap_config = .{};
     swap_hands.reset();
     key_lock.reset();
+    // Issue #401: テスト境界で action_resolver が前テストからリークすると
+    // keymap_lookup が未注入の状態でも resolver 経由で呼ばれてしまい panic する。
+    // reset() で resolver を null に戻し、 各呼び出し側 (startup / test setup)
+    // が `setActionResolver` を明示的に呼ぶ契約に統一する。
+    action_resolver = null;
 }
 
 // ============================================================

--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -73,17 +73,26 @@ pub const MATRIX_COLS = keymap_mod.MATRIX_COLS;
 /// ABI 側で KeyPos からフィールドを展開して内部 lookup に渡す薄い wrapper を持つ。
 pub const KeymapLookupFn = *const fn (l: u5, row: u8, col: u8) Keycode;
 
-/// 未設定時のデフォルト lookup。 常に `KC.NO` を返す。
+/// 未設定時のデフォルト lookup。 呼ばれた時点で panic する。
+///
 /// 関数ポインタを optional にすると hot path の null チェックが残るため、
-/// non-optional + デフォルト関数で安全側に倒す。
+/// non-optional + デフォルト関数で fail-fast に倒す。
+///
+/// 旧実装は `KC.NO` を返していたが、 production で `setKeymapLookup` の呼び忘れが
+/// 「全キー無反応」 のサイレント・バグになり原因特定が困難だった (Issue #401)。
+/// panic 化により未初期化状態を即座に検出する。
+///
+/// teardown (`clearKeymapLookup`) 後にこの関数が呼ばれた場合も panic するが、
+/// 現状のテストパターン (`fixture.deinit()` を `defer` で予約し、 その後
+/// `task()` を呼ばない) では問題にならない。
 fn defaultKeymapLookup(_: u5, _: u8, _: u8) Keycode {
-    return keycode.KC.NO;
+    @panic("keymap_lookup not initialized — call keyboard.setKeymapLookup() in startup");
 }
 
 /// 現在注入されているキーマップ参照関数。
 /// production startup (`main.zig`) / test setup (`test_fixture.zig`) で必ず設定する。
-/// 未設定の状態で `task()` が走っても `defaultKeymapLookup` が `KC.NO` を返すため
-/// クラッシュはしないが、 全キーが KC_NO 扱いになる。
+/// 未設定の状態で `keymap_lookup` が呼ばれた場合は `defaultKeymapLookup` が panic
+/// し、 setKeymapLookup の呼び忘れを即座に検出する (Issue #401)。
 var keymap_lookup: KeymapLookupFn = defaultKeymapLookup;
 
 /// キーマップ参照関数を注入する。
@@ -92,7 +101,10 @@ pub fn setKeymapLookup(lookup: KeymapLookupFn) void {
     keymap_lookup = lookup;
 }
 
-/// キーマップ参照関数をデフォルト (常に KC.NO) に戻す (test の teardown 用)。
+/// キーマップ参照関数をデフォルト (panic 動作) に戻す (test の teardown 用)。
+///
+/// teardown 後に `keymap_lookup` が呼ばれると panic する。 テスト独立性は
+/// 各テストの setup で `setKeymapLookup` が再注入されることで担保される。
 pub fn clearKeymapLookup() void {
     keymap_lookup = defaultKeymapLookup;
 }

--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -86,7 +86,7 @@ pub const KeymapLookupFn = *const fn (l: u5, row: u8, col: u8) Keycode;
 /// 現状のテストパターン (`fixture.deinit()` を `defer` で予約し、 その後
 /// `task()` を呼ばない) では問題にならない。
 fn defaultKeymapLookup(_: u5, _: u8, _: u8) Keycode {
-    @panic("keymap_lookup not initialized — call keyboard.setKeymapLookup() in startup");
+    @panic("keymap_lookup not initialized - call keyboard.setKeymapLookup() in startup");
 }
 
 /// 現在注入されているキーマップ参照関数。
@@ -170,9 +170,13 @@ pub fn init() void {
     matrix_state = .{0} ** MATRIX_ROWS;
     matrix_prev = .{0} ** MATRIX_ROWS;
     secure_consumed = .{0} ** MATRIX_ROWS;
-    // 注: keymap storage 自体のリセットは呼び出し側 (production startup / test fixture)
-    // の責務とする。 keyboard コアパイプラインは keymap storage の所有権を持たず、
-    // `keymap_lookup` 経由で参照するのみ。
+    // Issue #401: test 境界で keymap_lookup が前テストからリークすると、 panic
+    // 化された defaultKeymapLookup の検出網が無効化される。 init() で
+    // defaultKeymapLookup に戻し、 呼び出し側 (production startup / test setup)
+    // が `setKeymapLookup` を init() の後に必ず呼ぶ契約に統一する。
+    // 注: keymap storage 自体のリセットは呼び出し側の責務 (storage の所有権を
+    // keyboard コアパイプラインは持たないため)。
+    keymap_lookup = defaultKeymapLookup;
 }
 
 /// テスト用: フル初期化（ドライバ設定 + アクションリゾルバ設定含む）
@@ -370,8 +374,10 @@ fn testKeymapLookup(l: u5, row: u8, col: u8) Keycode {
 fn setup() *TestMockDriver {
     mock_driver = .{};
     test_keymap = keymap_mod.emptyKeymap();
-    setKeymapLookup(testKeymapLookup);
+    // 呼び出し順序契約 (Issue #401): init() は keymap_lookup をクリアするため、
+    // 必ず initTest の **後に** setKeymapLookup を呼ぶ。
     initTest(host.HostDriver.from(&mock_driver));
+    setKeymapLookup(testKeymapLookup);
     return &mock_driver;
 }
 

--- a/src/core/test_fixture.zig
+++ b/src/core/test_fixture.zig
@@ -143,10 +143,14 @@ pub const TestFixture = struct {
     }
 
     /// ドライバ登録を含むフルセットアップ（init() 後、self のアドレスが確定してから呼ぶ）
+    ///
+    /// 呼び出し順序契約 (Issue #401):
+    /// `keyboard.init()` (initTest 内で呼ばれる) は keymap_lookup を defaultKeymapLookup
+    /// に戻すため、 必ず `initTest` の **後に** `setKeymapLookup` を呼ぶこと。
     pub fn setup(self: *TestFixture) void {
         resetKeymap();
-        keyboard.setKeymapLookup(fixtureKeymapLookup);
         keyboard.initTest(keyboard.host.HostDriver.from(&self.driver));
+        keyboard.setKeymapLookup(fixtureKeymapLookup);
     }
 
     /// ボイラープレート削減用コンビニエンス API: out ポインタに対して init + setup を行う。
@@ -290,11 +294,15 @@ pub const TestFixture = struct {
     }
 
     /// Reset fixture state for next test
+    ///
+    /// 呼び出し順序契約 (Issue #401):
+    /// `init()` は keymap_lookup と action_resolver をクリアするため、
+    /// `setKeymapLookup` / `setActionResolver` は init() の **後に** 呼ぶこと。
     pub fn reset(self: *TestFixture) void {
         self.driver.reset();
         resetKeymap();
-        keyboard.setKeymapLookup(fixtureKeymapLookup);
         keyboard.init();
+        keyboard.setKeymapLookup(fixtureKeymapLookup);
         keyboard.host.setDriver(keyboard.host.HostDriver.from(&self.driver));
         @import("action.zig").setActionResolver(keyboard.keymapActionResolver);
     }


### PR DESCRIPTION
## Description

`src/core/keyboard.zig` の `defaultKeymapLookup` を「`KC.NO` を返す safe-fallback」から「`@panic` で即時 abort する fail-fast」に変更します。production で `setKeymapLookup` を呼び忘れた場合、これまでは「全キーが KC_NO 扱いで反応しない」サイレント・バグになっていましたが、本変更により未初期化状態が即座に検出されるようになります。

加えて、 ローカル devils-advocate / reviewer のレビューで判明した「テスト間のグローバル状態リーク」問題に対応するため、 `keyboard.init()` 内で `keymap_lookup` / `action_resolver` をデフォルト値にリセットし、 呼び出し順序契約 `init() → setKeymapLookup → setActionResolver` を確立しています。

### コミット
1. `dc785d75 refactor: defaultKeymapLookup を panic 化してサイレントバグ排除`
2. `69bc3d35 refactor: keyboard.init() で keymap_lookup / action_resolver をリセット`

### production binary サイズ影響 (ReleaseSmall 実測)
| 項目 | master | 本 PR | 差分 |
|------|--------|------|------|
| `.text+.rodata` | 24.3 KB | 24.3 KB | **0** |
| UF2 (madbd5_default) | 54784 B | 54784 B | **0** |
| ELF (madbd5_default) | 197132 B | 197132 B | **0** |

ReleaseSmall ビルドでは LLVM が `defaultKeymapLookup` を dead code として除去 (production startup で必ず `setKeymapLookup` で上書きされるため到達不能)。`strings` で panic message も検出されない。診断は debug build / serial console 経由でのみ得られる前提。

### テスト
- `zig build test --summary all`: 1117/1117 passed
- `zig build verify`: 15/15 steps succeeded
- 全 test バイナリの直接実行: EXIT=0（test runner 集計バグの偽緑を排除確認）

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Closes #401

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **PR Checklist** document and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (docstring)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. (qmk_abi 既存テストの修正で teardown 後 panic を踏まないよう保証)
- [x] I have tested the changes and verified that they work and don't break anything.