### PR TITLE
chore: keymapLookup docstring に PR #398 経緯を明示

### DIFF
--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -109,7 +109,7 @@ pub fn clearKeymapLookup() void {
     keymap_lookup = defaultKeymapLookup;
 }
 
-/// 外部 (qmk_abi 等) からの安定 entrypoint。 hot path は keymap_lookup を直接使用 (Issue #405、 PR #398 経緯)。
+/// 外部 ABI 向け安定 entrypoint。 内部 hot path は keymap_lookup を直接使用。
 pub fn keymapLookup(l: u5, row: u8, col: u8) Keycode {
     return keymap_lookup(l, row, col);
 }

--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -109,10 +109,7 @@ pub fn clearKeymapLookup() void {
     keymap_lookup = defaultKeymapLookup;
 }
 
-/// 注入済みキーマップ参照関数を呼び出すラッパー。
-/// production / test それぞれの storage に依存せず、 注入された lookup
-/// を経由してキーコードを取得するための統一エントリポイント。
-/// C ABI export (`compat/qmk_abi.zig`) からも参照される。
+/// 外部 (qmk_abi 等) からの安定 entrypoint。 hot path は keymap_lookup を直接使用 (Issue #405、 PR #398 経緯)。
 pub fn keymapLookup(l: u5, row: u8, col: u8) Keycode {
     return keymap_lookup(l, row, col);
 }


### PR DESCRIPTION
## Description

PR #404 で `src/core/keyboard.zig` に `pub fn keymapLookup(l, row, col)` 公開関数 (ABI 用の安定 entrypoint) を追加したが、 PR #398 で同様の構造を持つ `inline fn lookupKey` ラッパーを 「冗長」 として削除した経緯があり、 将来の読者にとって 「なぜ今度はラッパーを追加するのか」 が不明瞭だった。

そこで `keymapLookup` の docstring に以下を明示する:
- 本関数は外部 (qmk_abi 等) からの安定 entrypoint として残置している
- 内部 (resolveKeycode 等) は hot path のため `keymap_lookup` 関数ポインタを直接呼ぶ
- PR #398 で `lookupKey` ラッパーを削除した経緯への言及

なお、 「one short line max」 規約 (Issue #401 / PR #425 で 11 行 → 1 行に圧縮された経緯) を遵守し、 多行 docstring は避けて 1 行で表現する。

### 変更前
```zig
/// 注入済みキーマップ参照関数を呼び出すラッパー。
/// production / test それぞれの storage に依存せず、 注入された lookup
/// を経由してキーコードを取得するための統一エントリポイント。
/// C ABI export (`compat/qmk_abi.zig`) からも参照される。
pub fn keymapLookup(l: u5, row: u8, col: u8) Keycode {
```

### 変更後
```zig
/// 外部 (qmk_abi 等) からの安定 entrypoint。 hot path は keymap_lookup を直接使用 (Issue #405、 PR #398 経緯)。
pub fn keymapLookup(l: u5, row: u8, col: u8) Keycode {
```

## Types of Changes

- [x] Documentation

## Issues Fixed or Closed by This PR

* Closes #405

## Checklist

- [x] My code follows the code style of this project
- [x] I have tested the changes and verified that they work and don't break anything (`zig build elf` で コンパイル確認済み)