### PR TITLE
refactor: TestFixture.initAndSetup を削除して API surface を縮小

### DIFF
--- a/src/core/test_fixture.zig
+++ b/src/core/test_fixture.zig
@@ -150,34 +150,16 @@ pub const TestFixture = struct {
         keyboard.setKeymapLookup(fixtureKeymapLookup);
     }
 
-    /// ボイラープレート削減用コンビニエンス API: out ポインタに対して init + setup を行う。
+    /// ボイラープレート削減用コンビニエンス API: init + setup 後に追加の setup_fn を実行する。
+    /// 共通のキーマップセットアップ等を関数化して各テストから注入できる。
     ///
     /// out ポインタ版を採用する理由:
-    /// (1) `var fixture = TestFixture.initAndSetup();` のような戻り値式中使用を構文的に防ぐ
+    /// (1) `var fixture = TestFixture.withSetup(...);` のような戻り値式中使用を構文的に防ぐ
     ///     (戻り値が void のため、 値を受ける書き方ができない)。
     /// (2) アドレス安定性が API レベルの契約として明示される
     ///     (呼び出し側が `var fixture: TestFixture = undefined;` で記憶域を確保することを強制する)。
-    /// (3) host driver が保持する self pointer (`&self.driver`) のライフタイムが
+    /// (3) setup_fn / host driver が保持する `&out.driver` 等のライフタイムが
     ///     呼び出し側のスコープに紐付くという意図がシグネチャから明確になる。
-    ///
-    /// 標準の使い方:
-    /// ```zig
-    /// var fixture: TestFixture = undefined;
-    /// TestFixture.initAndSetup(&fixture);
-    /// defer fixture.deinit();
-    /// ```
-    pub fn initAndSetup(out: *TestFixture) void {
-        out.* = TestFixture.init();
-        out.setup();
-    }
-
-    /// ボイラープレート削減用コンビニエンス API: initAndSetup 後に追加の setup_fn を実行する。
-    /// 共通のキーマップセットアップ等を関数化して各テストから注入できる。
-    ///
-    /// out ポインタ版を採用する理由は `initAndSetup` と同じ:
-    /// (1) 戻り値式中使用を構文的に防ぐ
-    /// (2) アドレス安定性が API レベルの契約として明示される
-    /// (3) setup_fn が `&out.driver` 等を保持する可能性に備えたライフタイム意図の明確化
     ///
     /// 標準の使い方:
     /// ```zig
@@ -185,15 +167,19 @@ pub const TestFixture = struct {
     /// TestFixture.withSetup(&fixture, setupKeymap);
     /// defer fixture.deinit();
     /// ```
+    ///
+    /// 単に `init() + setup()` だけが必要な場合は本 API を使わず、
+    /// 直接 `var fixture = TestFixture.init(); fixture.setup();` と書くこと。
     pub fn withSetup(out: *TestFixture, comptime setup_fn: fn (*TestFixture) void) void {
-        TestFixture.initAndSetup(out);
+        out.* = TestFixture.init();
+        out.setup();
         setup_fn(out);
     }
 
     /// ボイラープレート削減用コンビニエンス API: init + setup + setKeymap を一括で実行する。
     /// 単純なキーマップだけを設定するテストで使用する。
     ///
-    /// out ポインタ版を採用する理由は `initAndSetup` と同じ:
+    /// out ポインタ版を採用する理由は `withSetup` と同じ:
     /// (1) 戻り値式中使用を構文的に防ぐ
     /// (2) アドレス安定性が API レベルの契約として明示される
     /// (3) host driver が保持する `&out.driver` のライフタイム意図の明確化
@@ -207,7 +193,8 @@ pub const TestFixture = struct {
     /// defer fixture.deinit();
     /// ```
     pub fn initWithKeymap(out: *TestFixture, keys: []const KeymapKey) void {
-        TestFixture.initAndSetup(out);
+        out.* = TestFixture.init();
+        out.setup();
         out.setKeymap(keys);
     }
 
@@ -431,27 +418,6 @@ test "TestFixture resolveKeycode transparency" {
 // ============================================================
 // コンビニエンス API のテスト
 // ============================================================
-
-test "TestFixture initAndSetup convenience API" {
-    var fixture: TestFixture = undefined;
-    TestFixture.initAndSetup(&fixture);
-    defer fixture.deinit();
-
-    fixture.setKeymap(&.{
-        KeymapKey.init(0, 0, 0, KC.A),
-    });
-
-    // 通常の init() + setup() と同じ挙動になることを確認
-    fixture.pressKey(0, 0);
-    fixture.runOneScanLoop();
-
-    try std.testing.expect(fixture.driver.keyboard_count >= 1);
-    try std.testing.expect(fixture.driver.lastKeyboardReport().hasKey(0x04));
-
-    fixture.releaseKey(0, 0);
-    fixture.runOneScanLoop();
-    try std.testing.expect(fixture.driver.lastKeyboardReport().isEmpty());
-}
 
 test "TestFixture withSetup convenience API" {
     const setup_fn = struct {

--- a/src/tests/test_caps_word.zig
+++ b/src/tests/test_caps_word.zig
@@ -47,7 +47,7 @@ const TAPPING_TERM = test_fixture.TAPPING_TERM;
 
 /// テスト共通セットアップ
 /// `TestFixture.withSetup` から呼び出されることを前提とし、 `setup()` 自体は呼ばない
-/// (withSetup → initAndSetup → setup() で既にセットアップ済み)。
+/// (withSetup → init() + setup() で既にセットアップ済み)。
 fn setupFixture(_: *TestFixture) void {
     timer.mockReset();
     caps_word.reset();

--- a/src/tests/test_leader.zig
+++ b/src/tests/test_leader.zig
@@ -48,7 +48,7 @@ const LEADER_TIMEOUT = leader.LEADER_TIMEOUT;
 
 /// テスト共通セットアップ
 /// `TestFixture.withSetup` から呼び出されることを前提とし、 `setup()` 自体は呼ばない
-/// (withSetup → initAndSetup → setup() で既にセットアップ済み)。
+/// (withSetup → init() + setup() で既にセットアップ済み)。
 fn setupFixture(_: *TestFixture) void {
     timer.mockReset();
     leader.reset();

--- a/src/tests/test_no_tapping.zig
+++ b/src/tests/test_no_tapping.zig
@@ -44,7 +44,7 @@ const KC = keycode_mod.KC;
 const TAPPING_TERM = @import("core").test_fixture.TAPPING_TERM;
 
 /// `TestFixture.withSetup` から呼び出されることを前提とし、 `setup()` 自体は呼ばない
-/// (withSetup → initAndSetup → setup() で既にセットアップ済み)。
+/// (withSetup → init() + setup() で既にセットアップ済み)。
 /// NO_ACTION_TAPPING のみ有効化。
 fn setupNoTapping(_: *TestFixture) void {
     action_code.no_action_tapping = true;
@@ -52,7 +52,7 @@ fn setupNoTapping(_: *TestFixture) void {
 }
 
 /// `TestFixture.withSetup` から呼び出されることを前提とし、 `setup()` 自体は呼ばない
-/// (withSetup → initAndSetup → setup() で既にセットアップ済み)。
+/// (withSetup → init() + setup() で既にセットアップ済み)。
 /// NO_ACTION_TAPPING + NO_ACTION_TAPPING_MODTAP_MODS を有効化。
 fn setupNoModTapMods(_: *TestFixture) void {
     action_code.no_action_tapping = true;

--- a/src/tests/test_repeat_key.zig
+++ b/src/tests/test_repeat_key.zig
@@ -58,7 +58,7 @@ const AUTO_SHIFT_TIMEOUT = auto_shift.AUTO_SHIFT_TIMEOUT;
 
 /// テスト用のフィクスチャセットアップ
 /// `TestFixture.withSetup` から呼び出されることを前提とし、 `setup()` 自体は呼ばない
-/// (withSetup → initAndSetup → setup() で既にセットアップ済み)。
+/// (withSetup → init() + setup() で既にセットアップ済み)。
 fn setupFixture(_: *TestFixture) void {
     timer.mockReset();
     repeat_key.reset();

--- a/src/tests/test_secure.zig
+++ b/src/tests/test_secure.zig
@@ -45,7 +45,7 @@ const TEST_UNLOCK_SEQUENCE = [_]secure.KeyPos{
 
 /// テスト共通セットアップ（C版 Secure::SetUp() 相当）
 /// `TestFixture.withSetup` から呼び出されることを前提とし、 `setup()` 自体は呼ばない
-/// (withSetup → initAndSetup → setup() で既にセットアップ済み)。
+/// (withSetup → init() + setup() で既にセットアップ済み)。
 fn setupFixture(_: *TestFixture) void {
     timer.mockReset();
     secure.reset();


### PR DESCRIPTION
## Description

`TestFixture.initAndSetup(out)` は単に `init()` + `setup()` を呼ぶだけのコンビニエンス API だったが、 PR #392 のローカル devils-advocate でも指摘された通り、 他 API で完全に表現可能で独立した関数として残す価値が薄かった。 API surface を縮小するため削除する。

### 削除理由

- `initAndSetup(out)` は単に `out.* = TestFixture.init(); out.setup();` の 2 行に展開できる。
- 元々の使用箇所は **コンビニエンス API 自身のテスト 1 件のみ** で、 通常のテストコードでは使用されていなかった。
- `withSetup` / `initWithKeymap` の内部実装でのみ利用されていたが、 これも 2 行に展開すれば足りる。

### 採用案 (案 b: 2 行展開)

Issue 本文の例にもある通り、 シンプルな案 b を採用:

```zig
out.* = TestFixture.init();
out.setup();
```

### 変更点

- `TestFixture.initAndSetup` を削除
- `withSetup` / `initWithKeymap` の内部呼び出しを `init() + setup()` の 2 行に展開
- `initAndSetup` 専用テスト (`test \"TestFixture initAndSetup convenience API\"`) を削除 (削除する関数自身のテストのため)
- `withSetup` の docstring を更新し、 単純な init+setup なら 2 行で直接書く方針を注記
- 各 `src/tests/test_*.zig` 内のコメント `withSetup → initAndSetup → setup()` を `withSetup → init() + setup()` に更新

## Types of Changes

- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

- Closes #410

## Checklist

- [x] My code follows the code style of this project
- [x] I have tested the changes and verified that they work and don't break anything (`zig build test` 緑)