### PR TITLE
test: TestFixture コンビニエンス API のエッジケーステスト追加

### DIFF
--- a/src/core/test_fixture.zig
+++ b/src/core/test_fixture.zig
@@ -491,3 +491,64 @@ test "TestFixture initWithKeymap convenience API" {
     try std.testing.expect(fixture.driver.keyboard_count >= 1);
     try std.testing.expect(fixture.driver.lastKeyboardReport().hasKey(0x07)); // KC_D
 }
+
+// ============================================================
+// コンビニエンス API のエッジケーステスト (Issue #411)
+// ============================================================
+
+test "TestFixture initWithKeymap: 空 keymap でも初期化が完了する" {
+    // 空配列を渡してもクラッシュせず、 全キーが KC_NO 状態になる。
+    // setup の冪等性 (resetKeymap → 全 KC_NO) と、 deinit が正常に呼べることを保証する。
+    var fixture: TestFixture = undefined;
+    TestFixture.initWithKeymap(&fixture, &.{});
+    defer fixture.deinit();
+
+    // 何のキーも登録されていないので、 (0,0) を押下しても
+    // KC_NO として処理され、 keyboard report にキーが乗らない。
+    fixture.pressKey(0, 0);
+    fixture.runOneScanLoop();
+    try std.testing.expect(fixture.driver.lastKeyboardReport().isEmpty());
+
+    fixture.releaseKey(0, 0);
+    fixture.runOneScanLoop();
+    try std.testing.expect(fixture.driver.lastKeyboardReport().isEmpty());
+}
+
+test "TestFixture initWithKeymap: out-of-range な row/col を含む keys は無視される (no-op)" {
+    // setKey は row >= MATRIX_ROWS / col >= MATRIX_COLS / layer >= MAX_LAYERS の
+    // いずれかが満たされた場合に no-op になる契約 (test_fixture.zig: setKey)。
+    // ここではユーザーが誤って out-of-range な KeymapKey を渡しても
+    // クラッシュせず、 範囲内の有効なキーだけが登録されることを検証する。
+
+    // 範囲外座標を comptime で計算 (MATRIX_ROWS=4, MATRIX_COLS=9 を超える値)
+    const oor_row: u8 = keymap_mod.MATRIX_ROWS;
+    const oor_col: u8 = keymap_mod.MATRIX_COLS;
+
+    var fixture: TestFixture = undefined;
+    TestFixture.initWithKeymap(&fixture, &.{
+        // 有効なキー
+        KeymapKey.init(0, 0, 0, KC.A),
+        // row 範囲外 → 無視されるべき
+        KeymapKey.init(0, oor_row, 0, KC.B),
+        // col 範囲外 → 無視されるべき
+        KeymapKey.init(0, 0, oor_col, KC.C),
+        // row, col 共に範囲外 → 無視されるべき
+        KeymapKey.init(0, oor_row, oor_col, KC.D),
+    });
+    defer fixture.deinit();
+
+    // 有効なキーは押せる
+    fixture.pressKey(0, 0);
+    fixture.runOneScanLoop();
+    try std.testing.expect(fixture.driver.lastKeyboardReport().hasKey(0x04)); // KC_A
+
+    fixture.releaseKey(0, 0);
+    fixture.runOneScanLoop();
+    try std.testing.expect(fixture.driver.lastKeyboardReport().isEmpty());
+
+    // 範囲外キーは登録されていないので、 マトリックス内の他の位置 (0, 1) は KC_NO のまま
+    // (= report にキーが乗らない)
+    fixture.pressKey(0, 1);
+    fixture.runOneScanLoop();
+    try std.testing.expect(fixture.driver.lastKeyboardReport().isEmpty());
+}

--- a/src/core/test_fixture.zig
+++ b/src/core/test_fixture.zig
@@ -520,7 +520,9 @@ test "TestFixture initWithKeymap: out-of-range な row/col を含む keys は無
     // ここではユーザーが誤って out-of-range な KeymapKey を渡しても
     // クラッシュせず、 範囲内の有効なキーだけが登録されることを検証する。
 
-    // 範囲外座標を comptime で計算 (MATRIX_ROWS=4, MATRIX_COLS=9 を超える値)
+    // 範囲外座標 = 最初の無効インデックス (= MATRIX_ROWS / MATRIX_COLS の値そのもの)。
+    // 実値はキーボード定義 (madbd5: 5x16, madbd34: 4x12 等) によって決まるため、
+    // 数値をハードコードせず keymap_mod の定数を直接参照する。
     const oor_row: u8 = keymap_mod.MATRIX_ROWS;
     const oor_col: u8 = keymap_mod.MATRIX_COLS;
 


### PR DESCRIPTION
## Description

`TestFixture.initWithKeymap` コンビニエンス API のエッジケーステストを 2 件追加。
PR #408 (Issue #392) で追加されたコンビニエンス API はハッピーパスのみカバーしていたため、
本 PR で境界条件・異常系をユニットテスト化する。

### 追加したテスト

1. **`TestFixture initWithKeymap: 空 keymap でも初期化が完了する`**
   - `&.{}` (空配列) を渡してもクラッシュせず初期化が完了することを検証
   - 全キーが `KC_NO` 状態のため、 押下しても `KeyboardReport` が空であることを確認
   - `setup` の冪等性 (`resetKeymap` → 全 `KC_NO`) と `deinit` の整合性を保証

2. **`TestFixture initWithKeymap: out-of-range な row/col を含む keys は無視される (no-op)`**
   - `MATRIX_ROWS` / `MATRIX_COLS` を超える `row` / `col` を持つ `KeymapKey` を渡しても
     クラッシュせず、 範囲内の有効なキーだけが登録されることを検証
   - 検証パターン: row 範囲外 / col 範囲外 / 両方範囲外 の 3 種
   - `setKey` の no-op 契約 (`test_fixture.zig` 冒頭コメント参照) をユニットテストで担保

### 省略したエッジケース

Issue #411 の提案のうち以下は省略 (理由を明記):

- **`setup_fn` が panic を起こした場合の deinit 整合性**: Zig の `@panic` を test 内で
  捕捉する標準的な手段は限られるため省略 (Issue 本文でも省略可と記載あり)。
- **同じ fixture に対して `initWithKeymap` を 2 度呼んだ場合の挙動**: 内部で
  `keyboard.initTest` → `host.setDriver` を再実行する設計のため、 安全性は
  `init() + setup()` を 2 度呼ぶ既存パターンと同等で、 専用テストの追加価値は低い。

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #411

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (`zig build test` 1119/1119 passed)