### PR TITLE
refactor: action_resolver に panic default を導入し qmk_abi test に注入を追加

### DIFF
--- a/src/compat/qmk_abi.zig
+++ b/src/compat/qmk_abi.zig
@@ -405,7 +405,20 @@ test "qmk_abi: timer_clear resets timer" {
 }
 
 test "qmk_abi: keyboard_init/task lifecycle" {
+    // Issue #420, #421, #423: keyboard_init() は keymap_lookup と action_resolver
+    // を panic 化された default にリセットする (defaultKeymapLookup /
+    // defaultActionResolver)。 task() の内部実装が将来 「常に lookup を呼ぶ」
+    // 形に変わっても fail しないよう、 init 直後に明示的に lookup と resolver
+    // を注入する。
+    //
+    // 呼び出し順序契約: keyboard_init() 内部で両者をリセットするため、 必ず
+    // init の **後に** setKeymapLookup / setActionResolver を呼ぶこと。
     keyboard_init();
+    keyboard_mod.setKeymapLookup(testNoCrashLookup);
+    defer keyboard_mod.clearKeymapLookup();
+    action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
+    defer action_mod.clearActionResolver();
+
     keyboard_task();
 }
 
@@ -413,7 +426,16 @@ test "qmk_abi: register_code/unregister_code with mock driver" {
     const FixedTestDriver = @import("core").test_driver.FixedTestDriver;
     const MockDriver = FixedTestDriver(32, 4);
 
+    // Issue #420: register_code / unregister_code 自体は lookup / resolver に
+    // 触れないが、 keyboard_init() による reset 後に未注入のまま放置すると
+    // テスト境界で stale な状態を残し、 後続テストや内部実装変更で偶発的な
+    // panic を招く。 各テストの自己完結性のため明示的に注入する。
     keyboard_init();
+    keyboard_mod.setKeymapLookup(testNoCrashLookup);
+    defer keyboard_mod.clearKeymapLookup();
+    action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
+    defer action_mod.clearActionResolver();
+
     var mock = MockDriver{};
     host_mod.setDriver(host_mod.HostDriver.from(&mock));
     defer host_mod.clearDriver();
@@ -431,7 +453,13 @@ test "qmk_abi: register_code modifier key" {
     const FixedTestDriver = @import("core").test_driver.FixedTestDriver;
     const MockDriver = FixedTestDriver(32, 4);
 
+    // Issue #420: 詳細は "register_code/unregister_code with mock driver" を参照。
     keyboard_init();
+    keyboard_mod.setKeymapLookup(testNoCrashLookup);
+    defer keyboard_mod.clearKeymapLookup();
+    action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
+    defer action_mod.clearActionResolver();
+
     host_mod.hostReset(); // real_mods を確実にクリアして前テストの影響を排除
     var mock = MockDriver{};
     host_mod.setDriver(host_mod.HostDriver.from(&mock));
@@ -450,7 +478,13 @@ test "qmk_abi: clear_keyboard clears all state" {
     const FixedTestDriver = @import("core").test_driver.FixedTestDriver;
     const MockDriver = FixedTestDriver(32, 4);
 
+    // Issue #420: 詳細は "register_code/unregister_code with mock driver" を参照。
     keyboard_init();
+    keyboard_mod.setKeymapLookup(testNoCrashLookup);
+    defer keyboard_mod.clearKeymapLookup();
+    action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
+    defer action_mod.clearActionResolver();
+
     var mock = MockDriver{};
     host_mod.setDriver(host_mod.HostDriver.from(&mock));
     defer host_mod.clearDriver();
@@ -462,7 +496,13 @@ test "qmk_abi: clear_keyboard clears all state" {
 }
 
 test "qmk_abi: host_set_driver/host_get_driver null" {
+    // Issue #420: 詳細は "register_code/unregister_code with mock driver" を参照。
     keyboard_init();
+    keyboard_mod.setKeymapLookup(testNoCrashLookup);
+    defer keyboard_mod.clearKeymapLookup();
+    action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
+    defer action_mod.clearActionResolver();
+
     host_set_driver(null);
     try testing.expectEqual(@as(?*const CHostDriver, null), host_get_driver());
 }
@@ -486,10 +526,14 @@ test "qmk_abi: action_exec does not crash" {
     // 呼び出し順序契約: keyboard_init() は内部で keymap_lookup と action_resolver を
     // リセットするため、 必ず init の **後に** setKeymapLookup / setActionResolver
     // を呼ぶこと。
+    //
+    // Issue #420: action_resolver も defer で teardown し、 後続テストへの
+    // 状態リークを防ぐ。
     keyboard_init();
     keyboard_mod.setKeymapLookup(testNoCrashLookup);
     defer keyboard_mod.clearKeymapLookup();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
+    defer action_mod.clearActionResolver();
 
     action_exec(0, 0, true, 100);
     action_exec(0, 0, false, 200);
@@ -497,10 +541,12 @@ test "qmk_abi: action_exec does not crash" {
 
 test "qmk_abi: process_record does not crash" {
     // Issue #401: action_exec does not crash と同様の理由で lookup / resolver を注入。
+    // Issue #420: action_resolver も defer で teardown する。
     keyboard_init();
     keyboard_mod.setKeymapLookup(testNoCrashLookup);
     defer keyboard_mod.clearKeymapLookup();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
+    defer action_mod.clearActionResolver();
 
     process_record(0, 0, true, 100);
     process_record(0, 0, false, 200);

--- a/src/core/action.zig
+++ b/src/core/action.zig
@@ -40,25 +40,38 @@ const KeyEvent = event_mod.KeyEvent;
 /// Given a KeyEvent, return the action code to execute.
 pub const ActionResolver = *const fn (event: KeyEvent) Action;
 
-/// `action_resolver` の安全な初期値。
-///
-/// 未注入のまま resolveAction が呼ばれた場合、 旧実装は `ACTION_NO` を黙って
-/// 返していたが、 production / test での `setActionResolver` 呼び忘れを検出
-/// できなかった (Issue #421, #423)。 panic する default を持たせることで、
-/// stale な状態でアクションパスを通したケースを即座にクラッシュとして捕捉する。
-///
-/// 各テスト境界では `action.reset()` または `clearActionResolver()` でこの
-/// default に戻し、 呼び出し側 (production startup / test setup) が
-/// `setActionResolver` を明示的に呼ぶ契約に統一する。
+/// production / test 起動経路で `setActionResolver` が呼び忘れられた場合の
+/// 安全網 (Issue #421, #423)。 旧実装は `null` フォールバックで `ACTION_NO` を
+/// 黙って返していたため呼び忘れを検出できなかった。 production startup
+/// (`keyboard.init()`) と qmk_abi の `defer clearActionResolver()` 経由で
+/// この panic 化 default に戻すことで、 stale な状態で resolveAction を
+/// 通したケースを即時クラッシュとして捕捉する。
 fn defaultActionResolver(ev: KeyEvent) Action {
     _ = ev;
     @panic("action_resolver not initialized - call action.setActionResolver() in startup");
 }
 
+/// テスト境界 (`action.reset()`) 用の no-op resolver。
+///
+/// `processAction` は OSL release path で内部的に `processRecord` →
+/// `resolveAction` を呼ぶため、 explicit action を渡すだけのテストでも
+/// resolver が必要になるケースがある。 これらのテストは本来 resolver の
+/// 振る舞いに依存しないので、 ACTION_NO を返して silent に処理させる。
+///
+/// production 起動経路では `keyboard.init()` がこの noop の上に
+/// `clearActionResolver()` で panic 化 default を再設定するため、
+/// 「呼び忘れ即 panic」契約は維持される。
+fn noopActionResolver(ev: KeyEvent) Action {
+    _ = ev;
+    return .{ .code = action_code.ACTION_NO };
+}
+
 /// アクション解決コールバック。
 ///
-/// 未設定の状態で `resolveAction` が呼ばれた場合は `defaultActionResolver` が
-/// panic し、 setActionResolver の呼び忘れを即座に検出する (Issue #421, #423)。
+/// 初期値は `defaultActionResolver` (panic) で、 `setActionResolver` 呼び忘れを
+/// 即座に検出する (Issue #421, #423)。 `action.reset()` が呼ばれると
+/// `noopActionResolver` (silent ACTION_NO) に切り替わり、 テスト境界での
+/// 偶発的な resolveAction 呼び出しを panic させずに通過させる。
 var action_resolver: ActionResolver = defaultActionResolver;
 
 /// 直前に解決されたキーコード（Key Lock 用）
@@ -794,10 +807,13 @@ pub fn reset() void {
     key_lock.reset();
     // Issue #401, #421, #423: テスト境界で action_resolver が前テストからリーク
     // すると、 keymap_lookup が未注入の状態でも resolver 経由で呼ばれてしまい
-    // panic する。 reset() で resolver を panic 化された default に戻し、 各
-    // 呼び出し側 (startup / test setup) が `setActionResolver` を明示的に呼ぶ
-    // 契約に統一する。
-    action_resolver = defaultActionResolver;
+    // 偶発的成功 / 失敗を招く。 reset() で resolver を `noopActionResolver` に
+    // 戻し、 stale な resolver が次テストへ漏れることを防ぐ。
+    //
+    // 一方 production 起動経路では `keyboard.init()` が reset() 後に
+    // `clearActionResolver()` を呼んで panic 化 default に再設定するため、
+    // production / qmk_abi で「呼び忘れ即 panic」の契約は引き続き保証される。
+    action_resolver = noopActionResolver;
 }
 
 // ============================================================

--- a/src/core/action.zig
+++ b/src/core/action.zig
@@ -40,7 +40,26 @@ const KeyEvent = event_mod.KeyEvent;
 /// Given a KeyEvent, return the action code to execute.
 pub const ActionResolver = *const fn (event: KeyEvent) Action;
 
-var action_resolver: ?ActionResolver = null;
+/// `action_resolver` の安全な初期値。
+///
+/// 未注入のまま resolveAction が呼ばれた場合、 旧実装は `ACTION_NO` を黙って
+/// 返していたが、 production / test での `setActionResolver` 呼び忘れを検出
+/// できなかった (Issue #421, #423)。 panic する default を持たせることで、
+/// stale な状態でアクションパスを通したケースを即座にクラッシュとして捕捉する。
+///
+/// 各テスト境界では `action.reset()` または `clearActionResolver()` でこの
+/// default に戻し、 呼び出し側 (production startup / test setup) が
+/// `setActionResolver` を明示的に呼ぶ契約に統一する。
+fn defaultActionResolver(ev: KeyEvent) Action {
+    _ = ev;
+    @panic("action_resolver not initialized - call action.setActionResolver() in startup");
+}
+
+/// アクション解決コールバック。
+///
+/// 未設定の状態で `resolveAction` が呼ばれた場合は `defaultActionResolver` が
+/// panic し、 setActionResolver の呼び忘れを即座に検出する (Issue #421, #423)。
+var action_resolver: ActionResolver = defaultActionResolver;
 
 /// 直前に解決されたキーコード（Key Lock 用）
 /// keyboard.zig の keymapActionResolver から設定され、processRecord で参照される。
@@ -60,7 +79,17 @@ pub fn setActionResolver(resolver: ActionResolver) void {
     action_resolver = resolver;
 }
 
-pub fn getActionResolver() ?ActionResolver {
+/// 注入済みの action_resolver を panic 化された default に戻す。
+///
+/// テスト境界で resolver がリークすると、 後続テストや内部実装変更で stale な
+/// resolver が呼ばれ偶発的な誤動作を招く。 各テストの setup で
+/// `setActionResolver` を再注入する契約と組み合わせることで、 resolver 注入の
+/// 呼び忘れを panic として即座に検出する。
+pub fn clearActionResolver() void {
+    action_resolver = defaultActionResolver;
+}
+
+pub fn getActionResolver() ActionResolver {
     return action_resolver;
 }
 
@@ -70,10 +99,7 @@ pub fn setLastResolvedKeycode(kc: keycode_mod.Keycode) void {
 }
 
 fn resolveAction(event: KeyEvent) Action {
-    if (action_resolver) |resolver| {
-        return resolver(event);
-    }
-    return .{ .code = action_code.ACTION_NO };
+    return action_resolver(event);
 }
 
 /// Layer tap operations (encoded in the key.code field)
@@ -766,11 +792,12 @@ pub fn reset() void {
     keymap_mod.keymap_config = .{};
     swap_hands.reset();
     key_lock.reset();
-    // Issue #401: テスト境界で action_resolver が前テストからリークすると
-    // keymap_lookup が未注入の状態でも resolver 経由で呼ばれてしまい panic する。
-    // reset() で resolver を null に戻し、 各呼び出し側 (startup / test setup)
-    // が `setActionResolver` を明示的に呼ぶ契約に統一する。
-    action_resolver = null;
+    // Issue #401, #421, #423: テスト境界で action_resolver が前テストからリーク
+    // すると、 keymap_lookup が未注入の状態でも resolver 経由で呼ばれてしまい
+    // panic する。 reset() で resolver を panic 化された default に戻し、 各
+    // 呼び出し側 (startup / test setup) が `setActionResolver` を明示的に呼ぶ
+    // 契約に統一する。
+    action_resolver = defaultActionResolver;
 }
 
 // ============================================================

--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -174,6 +174,13 @@ pub fn init() void {
     // 注: keymap storage 自体のリセットは呼び出し側の責務 (storage の所有権を
     // keyboard コアパイプラインは持たないため)。
     keymap_lookup = defaultKeymapLookup;
+    // Issue #421, #423: action_resolver を panic 化 default に再設定する。
+    // `action.reset()` 直後の resolver は `noopActionResolver` (silent) だが、
+    // production / qmk_abi 起動経路では init() の後に必ず `setActionResolver`
+    // を呼ぶ契約のため、 ここで panic 化 default に上書きして「呼び忘れ即
+    // panic」の保護網を張る。 内部 action.zig テストは `keyboard.init()` を
+    // 呼ばず `action.reset()` のみ呼ぶため、 noopActionResolver を維持する。
+    action.clearActionResolver();
 }
 
 /// テスト用: フル初期化（ドライバ設定 + アクションリゾルバ設定含む）


### PR DESCRIPTION
## Description

Issue #420 / #421 / #423 を Plan/DA 協議の結果決定された **案 E (Plan Round 2 推奨)** に基づき一括解決する。

### 背景

`keymap_lookup` は #401 で panic default 化されているが、 `action_resolver` は `null` で `ACTION_NO` silent fallback のままだった。 production / test での `setActionResolver` 呼び忘れを検出できず、 `action_resolver` 注入の呼び忘れが既存テストの偶発的成功で隠蔽されていた (#421, #423)。 また qmk_abi test 群は `keyboard_init()` 後に lookup / resolver を defer 注入する独自パターンを取りつつ resolver の defer teardown が欠落していた (#420)。

### 採用設計: 案 E (D2 のみ) + CI 修正で 2 段構成へ精緻化

初期実装は「`action.reset()` 直で panic default」だったが、 CI で `action.zig` 内部テストが `processAction` の OSL release path (`do_release_oneshot` → `processRecord` → `resolveAction`) で panic することが判明 (commit b00545e の verify ジョブ全 3 OS 失敗)。 **テスト境界は silent、 production 起動経路で panic** という 2 段構成にリファインした (commit 795f8ad)。

| 状態 | resolver 値 | セマンティクス |
|---|---|---|
| 初期値 (module load 時) | `defaultActionResolver` | panic |
| `action.reset()` 後 | `noopActionResolver` | silent ACTION_NO |
| `keyboard.init()` 後 | `defaultActionResolver` | panic (reset() の上に上書き) |
| `clearActionResolver()` 後 | `defaultActionResolver` | panic (qmk_abi defer teardown 用) |
| `setActionResolver(x)` 後 | `x` | 注入された resolver |

production / qmk_abi 起動経路は `keyboard.init()` を必ず通るため「呼び忘れ即 panic」 契約は維持。 一方 `action.zig` 内部テストは `keyboard.init()` を呼ばず `action.reset()` のみのため、 OSL release path が偶発的に resolveAction を踏んでも noop で silent に通過する。

### Round 2 で確定した事実

- **D1 (initTest シグネチャ拡張) は不採用**: API 表面増のコストに対し利益限定的。 panic default が呼び忘れを runtime 検出するため十分
- **A1 (initWithLookup wrapper) は撤回**: main.zig の 3 行は明示的に保ち、 panic default の対称性 (lookup / resolver) で揮発耐性を担保
- 低レベルテスト 5 件 (test_combo / test_tapping / test_oneshot / test_tap_hold_config / test_action_layer) は `keyboard.initTest` を経由せず `action.reset()` + `setActionResolver(custom)` を直接実行するため、 本変更は影響しない

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Closes #420 — qmk_abi test に lookup / resolver の明示注入と defer teardown を追加
* Closes #421 — comptime 強制の代替として、 panic default による runtime 即時検出で「呼び忘れ防止」の spirit を達成 (Won't Do as proposed, equivalent achieved)
* Closes #423 — `action_resolver` の panic 化 default により resolver 復活窓を構造的に解消

## 主な変更

### `src/core/action.zig`

- `defaultActionResolver` (panic) と `noopActionResolver` (silent ACTION_NO) を追加
- `action_resolver` を `?ActionResolver` から non-optional `ActionResolver = defaultActionResolver` に変更
- `clearActionResolver()` 公開 API を追加 (panic 化 default に戻す)
- `getActionResolver` の戻り値型を `?ActionResolver` → `ActionResolver` に変更
- `resolveAction` の null 分岐を削除 (ホットパス分岐削減)
- `reset()` は `noopActionResolver` にリセット (テスト境界用 silent)

### `src/core/keyboard.zig`

- `init()` 末尾で `action.clearActionResolver()` を呼び panic 化 default に上書き (production 起動経路の保護網)

### `src/compat/qmk_abi.zig`

- 7 件の test に `setKeymapLookup` / `setActionResolver` の明示注入と `defer clearKeymapLookup() / clearActionResolver()` を追加
- 呼び出し順序契約をコメントで明示 (init → setLookup / setResolver の順)

### 不変

`src/main.zig` / `src/core/test_fixture.zig` / 低レベルテスト 5 件は変更なし。

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the PR Checklist document and have made the appropriate changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the CONTRIBUTING document
- [x] I have added tests to cover my changes (qmk_abi test の注入は既存テスト群の堅牢化として機能)
- [x] I have tested the changes and verified that they work and don't break anything (CI verify ubuntu/macos/windows-latest 全 pass)

## 関連

- Plan / DA Round 1 (A1+A2 vs D1+D2 議論)
- Plan Round 2 (DA の「5 件矛盾」主張を事実誤認と検証、 案 E に縮小)
- Issue #401 (lookup の panic default 化、 本 PR で resolver にも対称適用)
- PR #431 (`clearKeymapLookup` → `resetKeymapLookupToPanic` rename、 同時期にマージ予定)
