### PR TITLE
refactor: clearKeymapLookup を resetKeymapLookupToPanic にリネーム

### DIFF
--- a/src/compat/qmk_abi.zig
+++ b/src/compat/qmk_abi.zig
@@ -488,7 +488,7 @@ test "qmk_abi: action_exec does not crash" {
     // を呼ぶこと。
     keyboard_init();
     keyboard_mod.setKeymapLookup(testNoCrashLookup);
-    defer keyboard_mod.clearKeymapLookup();
+    defer keyboard_mod.resetKeymapLookupToPanic();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
 
     action_exec(0, 0, true, 100);
@@ -499,7 +499,7 @@ test "qmk_abi: process_record does not crash" {
     // Issue #401: action_exec does not crash と同様の理由で lookup / resolver を注入。
     keyboard_init();
     keyboard_mod.setKeymapLookup(testNoCrashLookup);
-    defer keyboard_mod.clearKeymapLookup();
+    defer keyboard_mod.resetKeymapLookupToPanic();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
 
     process_record(0, 0, true, 100);
@@ -523,7 +523,7 @@ test "qmk_abi: keymap_key_to_keycode returns keycode from injected lookup" {
     keyboard_init();
     TestKeymapStorage.km = km_mod.emptyKeymap();
     keyboard_mod.setKeymapLookup(TestKeymapStorage.lookup);
-    defer keyboard_mod.clearKeymapLookup();
+    defer keyboard_mod.resetKeymapLookupToPanic();
 
     try testing.expectEqual(@as(u16, 0), keymap_key_to_keycode(0, event_mod.KeyPos{ .col = 0, .row = 0 }));
 

--- a/src/core/keyboard.zig
+++ b/src/core/keyboard.zig
@@ -82,7 +82,7 @@ pub const KeymapLookupFn = *const fn (l: u5, row: u8, col: u8) Keycode;
 /// 「全キー無反応」 のサイレント・バグになり原因特定が困難だった (Issue #401)。
 /// panic 化により未初期化状態を即座に検出する。
 ///
-/// teardown (`clearKeymapLookup`) 後にこの関数が呼ばれた場合も panic するが、
+/// teardown (`resetKeymapLookupToPanic`) 後にこの関数が呼ばれた場合も panic するが、
 /// 現状のテストパターン (`fixture.deinit()` を `defer` で予約し、 その後
 /// `task()` を呼ばない) では問題にならない。
 fn defaultKeymapLookup(_: u5, _: u8, _: u8) Keycode {
@@ -101,11 +101,16 @@ pub fn setKeymapLookup(lookup: KeymapLookupFn) void {
     keymap_lookup = lookup;
 }
 
-/// キーマップ参照関数をデフォルト (panic 動作) に戻す (test の teardown 用)。
+/// キーマップ参照関数を panic 動作 (デフォルト未初期化状態) にリセットする。
 ///
-/// teardown 後に `keymap_lookup` が呼ばれると panic する。 テスト独立性は
-/// 各テストの setup で `setKeymapLookup` が再注入されることで担保される。
-pub fn clearKeymapLookup() void {
+/// テスト独立性のため teardown で使用する。 リセット後に `keymap_lookup` が
+/// 呼ばれた場合は `defaultKeymapLookup` が panic し、 次のテストの setup で
+/// `setKeymapLookup` が再注入されることで前テストからの状態漏れを遮断する。
+///
+/// 名前のとおり 「panic 動作 (=未初期化デフォルト) に戻す」 セマンティクスで
+/// あり、 単に関数ポインタをクリアして null 化するわけではない (関数ポインタは
+/// non-optional のため null にはできない設計; 詳細は `defaultKeymapLookup` 参照)。
+pub fn resetKeymapLookupToPanic() void {
     keymap_lookup = defaultKeymapLookup;
 }
 
@@ -379,7 +384,7 @@ fn setup() *TestMockDriver {
 
 fn teardown() void {
     host.clearDriver();
-    clearKeymapLookup();
+    resetKeymapLookupToPanic();
 }
 
 test "keyboard_task: 単一キー押下→リリースでHIDレポートが正しく生成される" {

--- a/src/core/test_fixture.zig
+++ b/src/core/test_fixture.zig
@@ -200,7 +200,7 @@ pub const TestFixture = struct {
 
     pub fn deinit(_: *TestFixture) void {
         keyboard.host.clearDriver();
-        keyboard.clearKeymapLookup();
+        keyboard.resetKeymapLookupToPanic();
     }
 
     // ============================================================


### PR DESCRIPTION
## Description

Issue #422 で議論された通り、 `clearKeymapLookup` という関数名がセマンティクスを正しく表現していなかった (実際は「panic 化された default に戻す」動作で、 単に null クリアするわけではない) ため、 `resetKeymapLookupToPanic` にリネームする。

### 経緯

- Issue #401 で `keymap_lookup` を panic default 化、 teardown 用に `clearKeymapLookup` を追加
- 関数名が「クリアする」 と読めるため、 「未初期化状態に戻す = 次に呼ばれたら panic」 というセマンティクスが伝わりにくかった
- Issue #422 で rename 案を議論 → `resetKeymapLookupToPanic` で確定

## Types of Changes

- [x] Core
- [x] Enhancement/optimization (命名改善)

## Issues Fixed or Closed by This PR

* Closes #422

## 主な変更

- `src/core/keyboard.zig`: `clearKeymapLookup` → `resetKeymapLookupToPanic` に rename。 docstring を「panic 動作に戻す」 セマンティクスを明示する形に更新
- `src/compat/qmk_abi.zig`: 3 箇所の defer 呼び出しを新名にリネーム
- `src/core/test_fixture.zig`: 1 箇所の呼び出しを新名にリネーム

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the PR Checklist document and have made the appropriate changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests to cover my changes (機械的 rename のため不要)
- [ ] I have tested the changes and verified that they work and don't break anything (ローカルに zig 0.16.0 環境がなく `zig build test` / `zig build verify` 未実行。 CI で確認)

## 関連

- Issue #401 (`keymap_lookup` の panic default 化)
- PR #430 (#420+#421+#423 bundle、 同時期に `action_resolver` 側で対称的な API を導入)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CdML8XCgXESp4apPdWGodH)_