### PR TITLE
fix: PR #430 が追加した qmk_abi の clearKeymapLookup 呼び出しを resetKeymapLookupToPanic にリネーム

### DIFF
--- a/src/compat/qmk_abi.zig
+++ b/src/compat/qmk_abi.zig
@@ -415,7 +415,7 @@ test "qmk_abi: keyboard_init/task lifecycle" {
     // init の **後に** setKeymapLookup / setActionResolver を呼ぶこと。
     keyboard_init();
     keyboard_mod.setKeymapLookup(testNoCrashLookup);
-    defer keyboard_mod.clearKeymapLookup();
+    defer keyboard_mod.resetKeymapLookupToPanic();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
     defer action_mod.clearActionResolver();
 
@@ -432,7 +432,7 @@ test "qmk_abi: register_code/unregister_code with mock driver" {
     // panic を招く。 各テストの自己完結性のため明示的に注入する。
     keyboard_init();
     keyboard_mod.setKeymapLookup(testNoCrashLookup);
-    defer keyboard_mod.clearKeymapLookup();
+    defer keyboard_mod.resetKeymapLookupToPanic();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
     defer action_mod.clearActionResolver();
 
@@ -456,7 +456,7 @@ test "qmk_abi: register_code modifier key" {
     // Issue #420: 詳細は "register_code/unregister_code with mock driver" を参照。
     keyboard_init();
     keyboard_mod.setKeymapLookup(testNoCrashLookup);
-    defer keyboard_mod.clearKeymapLookup();
+    defer keyboard_mod.resetKeymapLookupToPanic();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
     defer action_mod.clearActionResolver();
 
@@ -481,7 +481,7 @@ test "qmk_abi: clear_keyboard clears all state" {
     // Issue #420: 詳細は "register_code/unregister_code with mock driver" を参照。
     keyboard_init();
     keyboard_mod.setKeymapLookup(testNoCrashLookup);
-    defer keyboard_mod.clearKeymapLookup();
+    defer keyboard_mod.resetKeymapLookupToPanic();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
     defer action_mod.clearActionResolver();
 
@@ -499,7 +499,7 @@ test "qmk_abi: host_set_driver/host_get_driver null" {
     // Issue #420: 詳細は "register_code/unregister_code with mock driver" を参照。
     keyboard_init();
     keyboard_mod.setKeymapLookup(testNoCrashLookup);
-    defer keyboard_mod.clearKeymapLookup();
+    defer keyboard_mod.resetKeymapLookupToPanic();
     action_mod.setActionResolver(keyboard_mod.keymapActionResolver);
     defer action_mod.clearActionResolver();
 


### PR DESCRIPTION
## Description

PR #431 (Issue #422) が `clearKeymapLookup` を `resetKeymapLookupToPanic` にリネームしたが、 並行して開発されていた PR #430 が追加した `qmk_abi.zig` の 5 箇所の `defer keyboard_mod.clearKeymapLookup()` 呼び出しは PR #431 の rename 対象外だった (PR #431 は pre-PR-#430 master ベースで作業されたため)。

両 PR が連続で master にマージされた結果、 master が以下の状態でビルドエラー:

- `keyboard.zig` から `clearKeymapLookup` 関数定義が削除済み
- `qmk_abi.zig` で 5 箇所がまだ削除済みの `clearKeymapLookup` を参照

本 PR で該当 5 箇所 (`qmk_abi.zig` lines 418, 435, 459, 484, 502) を全て `resetKeymapLookupToPanic` にリネームし、 master のビルドを修復する。

## Types of Changes

- [x] Bugfix

## Issues Fixed or Closed by This PR

* (master のビルド修復のみ、 issue 紐付けなし)

## 主な変更

`src/compat/qmk_abi.zig`: 5 箇所の `defer keyboard_mod.clearKeymapLookup()` を `defer keyboard_mod.resetKeymapLookupToPanic()` にリネーム

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the PR Checklist document and have made the appropriate changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests to cover my changes (機械的 rename のため不要)
- [ ] I have tested the changes and verified that they work and don't break anything (ローカルに zig 0.16.0 環境がなく `zig build verify` 未実行。 CI で確認)

## 再発防止

PR #430 と PR #431 は同じ qmk_abi.zig の同シンボル (`clearKeymapLookup`) に触れる関係だったが、 PR #430 が新規追加で PR #431 が rename だったため通常の merge conflict として検出されず、 両 PR の CI も個別 branch に対しては green で通過してしまっていた。 同種シンボルに触れる PR が並行開発される場合は、 後方の PR が前方の PR を merge してから rebase する運用が望ましい (PR #431 の merge 前に PR #430 の master 取り込みが必要だった)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01CdML8XCgXESp4apPdWGodH)_