### PR TITLE
test: leader.zig に sequenceFiveKeys MAX 境界テスト追加と既存テストへ境界拡張

### DIFF
--- a/src/core/leader.zig
+++ b/src/core/leader.zig
@@ -272,8 +272,19 @@ test "leaderSequenceTimedOut respects LEADER_TIMEOUT" {
     timer.mockReset();
     leaderStart();
     try testing.expect(!leaderSequenceTimedOut());
-    timer.mockAdvance(LEADER_TIMEOUT + 1);
+
+    // 直前 (LEADER_TIMEOUT - 1 経過): タイムアウトしない
+    timer.mockSet(LEADER_TIMEOUT - 1);
+    try testing.expect(!leaderSequenceTimedOut());
+
+    // ちょうど (LEADER_TIMEOUT 経過): "> LEADER_TIMEOUT" 比較のため false (Issue #438)
+    timer.mockSet(LEADER_TIMEOUT);
+    try testing.expect(!leaderSequenceTimedOut());
+
+    // 直後 (LEADER_TIMEOUT + 1 経過): タイムアウト
+    timer.mockSet(LEADER_TIMEOUT + 1);
     try testing.expect(leaderSequenceTimedOut());
+
     reset();
     timer.mockReset();
 }
@@ -326,6 +337,20 @@ test "processKeycode ignores release events" {
 test "processKeycode ends sequence when buffer full" {
     reset();
     timer.mockReset();
+
+    // overflow 時に leaderEnd が起動して callback が呼ばれることも検証 (Issue #438)
+    const TestHelper = struct {
+        var called: bool = false;
+        var captured_size: usize = 0;
+        fn cb(seq: []const u16) void {
+            called = true;
+            captured_size = seq.len;
+        }
+    };
+    TestHelper.called = false;
+    TestHelper.captured_size = 0;
+    setEndCallback(TestHelper.cb);
+
     _ = processKeycode(keycode_mod.QK_LEAD, true);
     for (0..MAX_SEQUENCE_LEN) |i| {
         _ = processKeycode(@intCast(KC.A + i), true);
@@ -334,6 +359,11 @@ test "processKeycode ends sequence when buffer full" {
     // overflow キーは消費されず action pipeline に渡る（C版互換: return false）
     try testing.expect(!processKeycode(KC.Z, true));
     try testing.expect(!leaderSequenceActive());
+    // leaderEnd 起動 → callback 呼び出し済み + sequence_size == MAX_SEQUENCE_LEN
+    try testing.expect(TestHelper.called);
+    try testing.expectEqual(MAX_SEQUENCE_LEN, TestHelper.captured_size);
+
+    clearEndCallback();
     reset();
     timer.mockReset();
 }
@@ -393,5 +423,29 @@ test "getSequence returns current buffer" {
     try testing.expectEqual(@as(usize, 2), seq.len);
     try testing.expectEqual(KC.X, seq[0]);
     try testing.expectEqual(KC.Y, seq[1]);
+    reset();
+}
+
+test "sequenceFiveKeys: leader_sequence が MAX_SEQUENCE_LEN 満杯時に正しく一致判定" {
+    // 境界値: leader_sequence バッファが MAX_SEQUENCE_LEN ちょうどで満杯のとき
+    // getSequence() 経由で sequenceFiveKeys が境界長で正しく動作する統合検証
+    // (既存 line 381 の sequenceFiveKeys テストはリテラル配列のみで、 leader バッファ満杯時の経路は別)
+    reset();
+    leaderStart();
+
+    const seq_keys = [MAX_SEQUENCE_LEN]u16{ KC.A, KC.B, KC.C, KC.D, KC.E };
+    for (seq_keys) |kc| {
+        try testing.expect(leaderSequenceAdd(kc));
+    }
+    try testing.expectEqual(@as(usize, MAX_SEQUENCE_LEN), leader_sequence_size);
+
+    const seq = getSequence();
+    try testing.expectEqual(@as(usize, MAX_SEQUENCE_LEN), seq.len);
+
+    try testing.expect(sequenceFiveKeys(seq, KC.A, KC.B, KC.C, KC.D, KC.E));
+    try testing.expect(!sequenceFiveKeys(seq, KC.A, KC.B, KC.C, KC.D, KC.F));
+    // 長さ不一致 (4 キー) の sequenceFourKeys は false
+    try testing.expect(!sequenceFourKeys(seq, KC.A, KC.B, KC.C, KC.D));
+
     reset();
 }

--- a/src/core/leader.zig
+++ b/src/core/leader.zig
@@ -429,7 +429,7 @@ test "getSequence returns current buffer" {
 test "sequenceFiveKeys: leader_sequence が MAX_SEQUENCE_LEN 満杯時に正しく一致判定" {
     // 境界値: leader_sequence バッファが MAX_SEQUENCE_LEN ちょうどで満杯のとき
     // getSequence() 経由で sequenceFiveKeys が境界長で正しく動作する統合検証
-    // (既存 line 381 の sequenceFiveKeys テストはリテラル配列のみで、 leader バッファ満杯時の経路は別)
+    // (既存 "sequenceFiveKeys matches correctly" はリテラル配列のみで、 leader バッファ満杯時の経路は別)
     reset();
     leaderStart();
 

--- a/src/core/leader.zig
+++ b/src/core/leader.zig
@@ -444,7 +444,7 @@ test "sequenceFiveKeys: leader_sequence が MAX_SEQUENCE_LEN 満杯時に正し�
 
     try testing.expect(sequenceFiveKeys(seq, KC.A, KC.B, KC.C, KC.D, KC.E));
     try testing.expect(!sequenceFiveKeys(seq, KC.A, KC.B, KC.C, KC.D, KC.F));
-    // 長さ不一致 (4 キー) の sequenceFourKeys は false
+    // sequenceFourKeys は内部で kc5=0 を渡すが seq[4]=KC.E のため false
     try testing.expect(!sequenceFourKeys(seq, KC.A, KC.B, KC.C, KC.D));
 
     reset();


### PR DESCRIPTION
## Description

`src/core/leader.zig` の境界値テスト強化 (Issue #438 対応)。実装変更なし、テストのみ。

devil's-advocate / reviewer 指摘 (重複・トートロジー) を踏まえて最小化した結果、以下の変更です。

### 変更内容

1. **既存 `leaderSequenceTimedOut respects LEADER_TIMEOUT` (line 270) を 3 ポイント検証に拡張**
   - 元の検証: `LEADER_TIMEOUT + 1` 経過でタイムアウト
   - 拡張後: `LEADER_TIMEOUT - 1` (false) / `LEADER_TIMEOUT` (false, `> LEADER_TIMEOUT` 比較) / `LEADER_TIMEOUT + 1` (true)
   - 動機: 比較演算子 `>` を `>=` に変更したリグレッションを検出可能にする

2. **既存 `processKeycode ends sequence when buffer full` (line 326) を callback 検証で拡張**
   - 元の検証: overflow キーで `consumed=false` かつ `!leaderSequenceActive()`
   - 拡張後: 加えて `setEndCallback` で登録した callback が起動し、`captured_size == MAX_SEQUENCE_LEN` であることを検証
   - 動機: leaderEnd 起動経路 (line 132-135) のリグレッションを明示検出

3. **`sequenceFiveKeys: leader_sequence が MAX_SEQUENCE_LEN 満杯時に正しく一致判定` を新規追加**
   - 既存 `sequenceFiveKeys matches correctly` (line 381) は配列リテラルのみで `leader_sequence` バッファ満杯経路が未カバー
   - `leaderStart` → `MAX_SEQUENCE_LEN` 個 add → `getSequence()` 経由で `sequenceFiveKeys` が境界長で動くことを統合検証

## Issue #438 受け入れ基準との対応

- 項目 1 (MAX_COMBOS ちょうど受理) / 項目 2 (空テーブル受理): devil's-advocate 指摘 (assert 裏返しのトートロジー) を受け、削除。combo.zig は無変更
- 項目 3 (`leaderSequenceAdd` MAX 詰めて満杯で false): 既存 `leaderSequenceAdd fills buffer up to MAX` (line 258) で完全カバー済み
- 項目 4 (`processKeycode` overflow): 既存テスト 326 を拡張して callback 起動を検証
- 項目 5 (`sequenceFiveKeys` MAX 境界): 新規テスト追加

## Types of Changes

- [x] Core (test addition / extension)

## Issues Fixed or Closed by This PR

* Closes #438

## Checklist

- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything.
  - `zig build test` で exit code 0 を確認 (uf2gen / flash の Error 表示はネガティブテストの想定 stderr)