### PR TITLE
chore: Dependabot の GitHub Actions 更新に3日間の cooldown を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,6 @@ updates:
       day: "saturday"
       time: "06:30"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Description

Dependabot が管理する GitHub Actions の更新に対して、3日間の cooldown を追加しました。

新しいバージョンがリリースされてから3日間は更新 PR が作成されなくなり、リリース直後の不安定なバージョンを取り込むリスクを減らせます。`cooldown.default-days` を `3` に設定しています。

なお、既存の `weekly` スケジュール（Dependabot が更新をチェックするタイミング）は cooldown とは独立した設定のため変更していません。

## Types of Changes

- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* なし

## Checklist

- [x] I have read the **CONTRIBUTING** document.