### PR TITLE
chore: GitHub Actions をフル commit SHA にピン留め

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.133
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Disable safe.directory check
       run : git config --global --add safe.directory '*'
 
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
 
     - name: Get changed files
       id: file_changes
-      uses: tj-actions/changed-files@v47
+      uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
       with:
         use_rest_api: true
 

--- a/.github/workflows/zig_test.yml
+++ b/.github/workflows/zig_test.yml
@@ -38,10 +38,10 @@ jobs:
     name: zig fmt --check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Zig
-      uses: mlugg/setup-zig@v2
+      uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
       with:
         version: ${{ env.ZIG_VERSION }}
 
@@ -58,13 +58,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # setup-zig@v2 は use-cache: true (デフォルト) で Zig global cache
     # (~/.cache/zig 等) を OS ごとに自動キャッシュする。 actions/cache@v5
     # での重ねがけは冗長 + 干渉リスクのため使用しない。
     - name: Setup Zig
-      uses: mlugg/setup-zig@v2
+      uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
       with:
         version: ${{ env.ZIG_VERSION }}
 
@@ -72,7 +72,7 @@ jobs:
     # キーには runner.os / runner.arch / Zig version を含め、
     # 環境変更時に古い壊れた cache を復元しないようにする。
     - name: Cache Zig local cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .zig-cache
         key: ${{ runner.os }}-${{ runner.arch }}-zig-${{ env.ZIG_VERSION }}-local-${{ hashFiles('build.zig.zon', 'build.zig', 'src/**', 'tools/**') }}


### PR DESCRIPTION
## Description

GitHub Actions の第三者アクション参照を、可変タグからフルレングス commit SHA + バージョンコメントへピン留めし、タグすり替え型サプライチェーン攻撃（上流アカウント侵害時のタグ差し替え）への耐性を高めます。

**挙動を変えない「ピン留めのみ」の変更**です。各アクションは現在タグが指している commit にそのまま固定しており、実行されるコードは変わりません。バージョンコメント（`# vX.Y.Z`）付きのため、Dependabot は SHA ピン後も更新提案を継続します。

### 対象（全 5 アクション / 9 箇所）

| アクション | 旧参照 | 新 SHA（コメント） | 箇所 |
|---|---|---|---|
| `actions/checkout` | `@v6.0.2` | `de0fac2e…` `# v6.0.2` | claude.yml / format.yml / zig_test.yml（計 4） |
| `anthropics/claude-code-action` | `@v1.0.133` | `787c5a0c…` `# v1.0.133` | claude.yml |
| `tj-actions/changed-files` | `@v47` | `24d32ffd…` `# v47.0.0` | format.yml |
| `mlugg/setup-zig` | `@v2` | `d1434d08…` `# v2.2.1` | zig_test.yml（2） |
| `actions/cache` | `@v5` | `27d5ce7f…` `# v5.0.5` | zig_test.yml |

### 留意事項

- **`tj-actions/changed-files`**: 可変タグ `@v47` が現在 **v47.0.0（最古）** を指していたため、現状維持として v47.0.0 の SHA に固定しました（最新は v47.0.6）。挙動を変えないため本 PR では現状維持とし、最新化はマージ後の Dependabot 提案に委ねます。tj-actions は過去にサプライチェーン汚染（CVE-2025-30066）の前例があり、SHA ピンの優先対象です。
- **Dependabot PR #444（checkout 6.0.3）/ #443（claude-code-action 1.0.134）** とは別管理です。本 PR マージ後はこれらが同一行を編集するため rebase が必要になります（Dependabot が SHA + version comment 形式で再提案します）。
- `claude.yml` への変更は default ブランチ（master）反映後に有効化されるため、本 PR 自体のレビュー実行には影響しません。

## Types of Changes

- [x] Enhancement/optimization（CI サプライチェーンセキュリティ強化）

## Issues Fixed or Closed by This PR

* なし

## Checklist

- [x] 挙動を変えないピン留めのみの変更で、各アクションは現行タグが指す commit に固定
- [x] バージョンコメント付与により Dependabot の自動更新を維持
- [x] リポジトリ内の全ワークフロー（claude/format/zig_test）の第三者アクション参照を網羅
