### PR TITLE
chore: 陳腐化するバージョン参照コメントを版非依存化

### DIFF
--- a/.claude/skills/build-flash-improvements.md
+++ b/.claude/skills/build-flash-improvements.md
@@ -135,7 +135,7 @@ build.zig 使用 API について 0.16.0 リリースノート確認 + ローカ
 1. `strategy.matrix.os: [ubuntu-latest, macos-latest, windows-latest]`
 2. `zig fmt --check src tools build.zig` ステップ追加
 3. `zig build test` + `zig build` を `zig build verify` に統合
-4. `actions/cache@v4` で `~/.cache/zig`, `.zig-cache` をキャッシュ
+4. `actions/cache` で `~/.cache/zig`, `.zig-cache` をキャッシュ
 
 **Acceptance Criteria**
 - [ ] 3 OS で `zig build verify` が緑（ユニットテスト + cross-compile）

--- a/.claude/skills/zig-build-conventions.md
+++ b/.claude/skills/zig-build-conventions.md
@@ -228,7 +228,7 @@ runs-on: ${{ matrix.os }}
 
 ### キャッシュ
 ```yaml
-- uses: actions/cache@v4
+- uses: actions/cache
   with:
     path: |
       ~/.cache/zig
@@ -245,7 +245,7 @@ runs-on: ${{ matrix.os }}
 `test` + `build` 別呼出より効率的（共通モジュールの再コンパイル削減）。
 
 ### shallow clone と git rev-parse (issue Q3)
-GitHub Actions の `actions/checkout@v6` のデフォルトは `fetch-depth: 1`。`git rev-parse --short HEAD` は動くが `git describe` 系 tag ベースは動かない。
+GitHub Actions の `actions/checkout` のデフォルトは `fetch-depth: 1`。`git rev-parse --short HEAD` は動くが `git describe` 系 tag ベースは動かない。
 
 ```zig
 // build.zig 内で git 実行

--- a/.github/workflows/zig_test.yml
+++ b/.github/workflows/zig_test.yml
@@ -60,8 +60,8 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-    # setup-zig@v2 は use-cache: true (デフォルト) で Zig global cache
-    # (~/.cache/zig 等) を OS ごとに自動キャッシュする。 actions/cache@v5
+    # setup-zig は use-cache: true (デフォルト) で Zig global cache
+    # (~/.cache/zig 等) を OS ごとに自動キャッシュする。 actions/cache
     # での重ねがけは冗長 + 干渉リスクのため使用しない。
     - name: Setup Zig
       uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1


### PR DESCRIPTION
## Description

Dependabot は `uses:` 行の SHA と行末 `# vX.Y.Z` コメントのみを更新し、散文コメントやドキュメント中に手書きされたアクションバージョン参照（例: `actions/cache@v5`）は更新しません。そのためアクションをバンプするたびにこれらの記述が陳腐化（レガシー化）します。

本PRでは、将来のバージョン更新で再び陳腐化しないよう、手書きのバージョン参照から**版番号を除去して版非依存**にします（最新版へ更新するのではなく、版に依存しない表現へ変更）。`uses:` 行末の SHA ピン留めバージョンコメントは Dependabot が同期維持するため対象外で、一切変更していません。

### 変更箇所（計4箇所 / 3ファイル）
- `.github/workflows/zig_test.yml`（散文コメント）: `setup-zig@v2` → `setup-zig`、`actions/cache@v5` → `actions/cache`
- `.claude/skills/zig-build-conventions.md`: コード例 `actions/cache@v4` → `actions/cache`、説明文 `actions/checkout@v6` → `actions/checkout`
- `.claude/skills/build-flash-improvements.md`（提案文）: `actions/cache@v4` → `actions/cache`

いずれもコメント・ドキュメント文言のみの変更で、ワークフローの動作・設定値・コードには影響しません。

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* なし（Dependabot PR #449 / #450 / #451 マージ後のフォローアップ清掃）

## Checklist

- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).